### PR TITLE
添加了一些注释，并优化了下载逻辑，将 AsParallel 替换为 Parallel.ForEach，提高验证效率。

### DIFF
--- a/MinecraftLaunch/Components/Downloader/FileDownloader.cs
+++ b/MinecraftLaunch/Components/Downloader/FileDownloader.cs
@@ -10,8 +10,14 @@ using Timer = System.Timers.Timer;
 
 namespace MinecraftLaunch.Components.Downloader;
 
-public sealed class FileDownloader {
-    private class DownloadStates {
+
+/// <summary>
+/// 文件下载器，支持单文件和批量文件下载，支持多线程分块下载。
+/// </summary>
+public sealed class FileDownloader
+{
+    private class DownloadStates
+    {
         public required string Url { get; init; }
         public required string LocalPath { get; init; }
         public long? TotalBytes { get; set; }
@@ -22,16 +28,22 @@ public sealed class FileDownloader {
         public long TotalChunks { get; set; } = 0;
         private readonly object _chunkOrganizerLock = new();
 
-        public (long start, long end)? NextChunk() {
+        /// <summary>
+        /// 获取下一个需要下载的分块范围。
+        /// (english) Get the next chunk range to download.
+        /// </summary>
+        public (long start, long end)? NextChunk()
+        {
             long totalBytes = (long)TotalBytes!;
             long start, end;
-            lock (_chunkOrganizerLock) {
+            lock (_chunkOrganizerLock)
+            {
                 if (_chunkScheduled == TotalChunks)
                     return null;
                 start = _chunkScheduled * ChunkSize;
                 _chunkScheduled++;
             }
-            // Handle the last chunk
+            // 处理最后一个分块
             end = Math.Min(start + ChunkSize, totalBytes) - 1;
             return (start, end);
         }
@@ -48,92 +60,128 @@ public sealed class FileDownloader {
 
     internal IFlurlClient FlurlClient => HttpUtil.FlurlClient;
 
-    private const int DOWNLOAD_BUFFER_SIZE = 4096;
-
+    private const int DEFAULT_DOWNLOAD_BUFFER_SIZE = 8192; // 增大缓冲区大小
     private readonly DownloaderConfig _config;
     private readonly SemaphoreSlim _globalDownloadTasksSemaphore;
 
-    public FileDownloader(int maxThread = 64) {
+    /// <summary>
+    /// 构造函数，初始化文件下载器。
+    /// Initialize file downloader.
+    /// </summary>
+    /// <param name="maxThread">最大并发线程数。</param>
+    public FileDownloader(int maxThread = 64)
+    {
         _config = new DownloaderConfig(1024 * 1024, maxThread, maxThread);
         _globalDownloadTasksSemaphore = new SemaphoreSlim(maxThread, maxThread);
     }
 
-    public static string GetSpeedText(double speed) {
+    /// <summary>
+    /// 将下载进度格式化为可读字符串。
+    /// Format download speed to a readable string.
+    /// </summary>
+    public static string GetSpeedText(double speed)
+    {
         const double kilobyte = 1024.0;
         const double megabyte = kilobyte * 1024.0;
         const double gigabyte = megabyte * 1024.0;
 
-        if (speed < kilobyte) {
+        if (speed < kilobyte)
+        {
             return speed.ToString("0") + " B/s"; // 字节
-        } else if (speed < megabyte) {
+        }
+        else if (speed < megabyte)
+        {
             return (speed / kilobyte).ToString("0.0") + " KB/s"; // 千字节
-        } else if (speed < gigabyte) {
+        }
+        else if (speed < gigabyte)
+        {
             return (speed / megabyte).ToString("0.00") + " MB/s"; // 兆字节
-        } else return "0";
+        }
+        else
+        {
+            return (speed / gigabyte).ToString("0.00") + " GB/s"; // 千兆字节
+        }
     }
 
-    public async Task<DownloadResult> DownloadFileAsync(DownloadRequest request, CancellationToken cancellationToken = default) {
-        try {
+    /// <summary>
+    /// 异步下载单个文件。
+    /// Async download single file.
+    /// </summary>
+    public async Task<DownloadResult> DownloadFileAsync(DownloadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
             cancellationToken.ThrowIfCancellationRequested();
-            await _globalDownloadTasksSemaphore.WaitAsync(cancellationToken);
-        } catch (OperationCanceledException) {
+            await _globalDownloadTasksSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
             return new DownloadResult(DownloadResultType.Cancelled);
         }
 
-        try {
-            await DownloadFileDriverAsync(request, cancellationToken);
+        try
+        {
+            await DownloadFileDriverAsync(request, cancellationToken).ConfigureAwait(false);
             return new DownloadResult(DownloadResultType.Successful);
-        } catch (TaskCanceledException) {
+        }
+        catch (TaskCanceledException)
+        {
             return new DownloadResult(DownloadResultType.Cancelled);
-        } catch (Exception e) {
-            return new DownloadResult(DownloadResultType.Failed) {
+        }
+        catch (Exception e)
+        {
+            return new DownloadResult(DownloadResultType.Failed)
+            {
                 Exception = e
             };
-        } finally {
+        }
+        finally
+        {
             _globalDownloadTasksSemaphore.Release();
         }
     }
 
-    public async Task<GroupDownloadResult> DownloadFilesAsync(GroupDownloadRequest request, CancellationToken cancellationToken = default) {
+    /// <summary>
+    /// 异步批量下载多个文件。
+    /// (english) Async download multiple files.
+    /// </summary>
+    public async Task<GroupDownloadResult> DownloadFilesAsync(GroupDownloadRequest request, CancellationToken cancellationToken = default)
+    {
         Timer timer = new(TimeSpan.FromSeconds(1));
-        List<Task> downloadTasks = [];
-        ConcurrentDictionary<DownloadRequest, DownloadResult> failed = [];
+        List<Task> downloadTasks = new();
+        ConcurrentDictionary<DownloadRequest, DownloadResult> failed = new();
         long bytesReceived = 0;
         long previousBytesReceived = 0;
 
         timer.Elapsed += (_, _) => {
-            TimeSpan elapsedTime = DateTime.Now - request.StartTime;
             long diffBytes = bytesReceived - previousBytesReceived;
             previousBytesReceived = bytesReceived;
 
-            double speed = diffBytes / 1;
+            double speed = diffBytes / 1.0;
             request.DownloadSpeedChanged?.Invoke(speed);
         };
 
         timer.Start();
-        foreach (var req in request.Files) {
+        foreach (var req in request.Files)
+        {
             var r = req;
-            string url = req.Url;
-            string localPath = req.FileInfo.FullName;
-
             r.BytesDownloaded = b => {
-                bytesReceived += b;
+                Interlocked.Add(ref bytesReceived, b);
             };
 
-            url = DownloadMirrorManager.BmclApi.TryFindUrl(url);
+            string url = DownloadMirrorManager.BmclApi.TryFindUrl(req.Url);
             downloadTasks.Add(DownloadFileInGroupAsync(r, request, failed, cancellationToken));
         }
 
-        await Task.WhenAll(downloadTasks);
+        await Task.WhenAll(downloadTasks).ConfigureAwait(false);
         timer.Stop();
 
-        DownloadResultType type = DownloadResultType.Successful;
-        if (cancellationToken.IsCancellationRequested)
-            type = DownloadResultType.Cancelled;
-        else if (failed.Count > 0)
-            type = DownloadResultType.Failed;
+        DownloadResultType type = cancellationToken.IsCancellationRequested
+            ? DownloadResultType.Cancelled
+            : failed.Count > 0 ? DownloadResultType.Failed : DownloadResultType.Successful;
 
-        return new GroupDownloadResult {
+        return new GroupDownloadResult
+        {
             Failed = failed.ToFrozenDictionary(),
             Type = type
         };
@@ -141,128 +189,166 @@ public sealed class FileDownloader {
 
     #region Privates
 
-    private async Task DownloadFileDriverAsync(DownloadRequest request, CancellationToken cancellationToken = default) {
+    /// <summary>
+    /// 下载文件的核心方法。
+    /// (english) File downloader core driver method.
+    /// </summary>
+    private async Task DownloadFileDriverAsync(DownloadRequest request, CancellationToken cancellationToken = default)
+    {
         string url = DownloadMirrorManager.BmclApi.TryFindUrl(request.Url);
         string localPath = request.FileInfo.FullName;
 
-        (var flurlResponse, url) = await PrepareForDownloadAsync(url, cancellationToken);
+        (var flurlResponse, url) = await PrepareForDownloadAsync(url, cancellationToken).ConfigureAwait(false);
         var httpResponse = flurlResponse.ResponseMessage;
 
-        DownloadStates states = new() {
+        DownloadStates states = new()
+        {
             Url = url,
             LocalPath = localPath,
             ChunkSize = _config.ChunkSize
         };
 
         bool useMultiPart = false;
-        if (httpResponse.Content.Headers.ContentLength is long contentLength) {
+        if (httpResponse.Content.Headers.ContentLength is long contentLength)
+        {
             request.Size = contentLength;
             states.TotalBytes = contentLength;
 
             var rangeResponse = await FlurlClient.Request(url)
-                .GetAsync(cancellationToken:cancellationToken);
+                .GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
             useMultiPart = rangeResponse.StatusCode is 206;
         }
-
-        // Status changed
-        //request.FileSizeReceived?.Invoke(states.TotalBytes);
 
         string destinationDir = Path.GetDirectoryName(localPath);
         if (destinationDir is not null)
             Directory.CreateDirectory(destinationDir);
 
-        if (useMultiPart) {
-            await DownloadMultiPartAsync(states, request, cancellationToken);
-        } else {
-            await DownloadSinglePartAsync(states, request, cancellationToken);
+        if (useMultiPart)
+        {
+            await DownloadMultiPartAsync(states, request, cancellationToken).ConfigureAwait(false);
         }
-
+        else
+        {
+            await DownloadSinglePartAsync(states, request, cancellationToken).ConfigureAwait(false);
+        }
     }
 
-    private async Task<(IFlurlResponse Response, string RedirectedUrl)> PrepareForDownloadAsync(string url, CancellationToken cancellationToken = default) {
-        // Get header
+    /// <summary>
+    /// 准备下载并检查 URL 是否重定向。
+    /// (english) Ready for download and check if the URL is redirected.
+    /// </summary>
+    private async Task<(IFlurlResponse Response, string RedirectedUrl)> PrepareForDownloadAsync(string url, CancellationToken cancellationToken = default)
+    {
         var response = await FlurlClient.Request(url)
-            .HeadAsync(cancellationToken: cancellationToken);
+            .HeadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        if (response.StatusCode is 302) {
+        if (response.StatusCode is 302)
+        {
             var redirectUrl = response.ResponseMessage?.Headers?.Location?.AbsoluteUri;
             if (redirectUrl is not null)
-                return await PrepareForDownloadAsync(redirectUrl, cancellationToken);
+                return await PrepareForDownloadAsync(redirectUrl, cancellationToken).ConfigureAwait(false);
         }
 
         response.ResponseMessage.EnsureSuccessStatusCode();
         return (response, url);
     }
 
-    private async Task WriteStreamToFile(Stream contentStream, FileStream fileStream, Memory<byte> buffer, DownloadRequest request, CancellationToken cancellationToken = default) {
-        int bytesRead = 0;
-        while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken)) > 0) {
-            await fileStream.WriteAsync(buffer[0..bytesRead], cancellationToken);
-            request.BytesDownloaded?.Invoke(bytesRead);
-        }
-    }
-
-    private async Task DownloadSinglePartAsync(DownloadStates states, DownloadRequest request, CancellationToken cancellationToken = default) {
+    /// <summary>
+    /// 单线程下载文件。
+    /// (english) Single-threaded download file.
+    /// </summary>
+    private async Task DownloadSinglePartAsync(DownloadStates states, DownloadRequest request, CancellationToken cancellationToken = default)
+    {
         using var response = await FlurlClient.Request(states.Url)
-            .GetAsync(cancellationToken: cancellationToken);
+            .GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        using var contentStream = await response.ResponseMessage.Content.ReadAsStreamAsync(cancellationToken);
+        using var contentStream = await response.ResponseMessage.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         using var fileStream = new FileStream(states.LocalPath, FileMode.Create, FileAccess.Write);
+
         if (states.TotalBytes is long size)
             fileStream.SetLength(size);
 
-        byte[] downloadBufferArr = ArrayPool<byte>.Shared.Rent(DOWNLOAD_BUFFER_SIZE);
-        Memory<byte> downloadBuffer = downloadBufferArr.AsMemory(0, DOWNLOAD_BUFFER_SIZE);
-        await WriteStreamToFile(contentStream, fileStream, downloadBuffer, request, cancellationToken);
+        byte[] downloadBufferArr = ArrayPool<byte>.Shared.Rent(DEFAULT_DOWNLOAD_BUFFER_SIZE);
+        Memory<byte> downloadBuffer = downloadBufferArr.AsMemory(0, DEFAULT_DOWNLOAD_BUFFER_SIZE);
+        await WriteStreamToFile(contentStream, fileStream, downloadBuffer, request, cancellationToken).ConfigureAwait(false);
         ArrayPool<byte>.Shared.Return(downloadBufferArr);
     }
 
-    private async Task DownloadMultiPartAsync(DownloadStates states, DownloadRequest request, CancellationToken cancellationToken = default) {
-        long fileSize = (long)states.TotalBytes!; // Not null in multipart download
+    /// <summary>
+    /// 多线程下载文件。
+    /// (english) Multi-threaded download file.
+    /// </summary>
+    private async Task DownloadMultiPartAsync(DownloadStates states, DownloadRequest request, CancellationToken cancellationToken = default)
+    {
+        long fileSize = (long)states.TotalBytes!;
 
         long totalChunks = Math.DivRem(fileSize, ChunkSize, out long remainder);
         if (remainder > 0)
             totalChunks++;
         states.TotalChunks = totalChunks;
 
-        // Pre-allocate the file with the desired size
         using var fileStream = new FileStream(states.LocalPath, FileMode.Create, FileAccess.Write, FileShare.Write);
         fileStream.SetLength(fileSize);
 
-        // Initialize workers
         int numberOfWorkers = (int)Math.Min(WorkersPerDownloadTask, totalChunks);
         Task[] workers = new Task[numberOfWorkers];
-        for (int i = 0; i < numberOfWorkers; i++) {
+        for (int i = 0; i < numberOfWorkers; i++)
+        {
             workers[i] = MultipartDownloadWorker(states, request, cancellationToken);
         }
-        await Task.WhenAll(workers);
+        await Task.WhenAll(workers).ConfigureAwait(false);
     }
 
-    private async Task MultipartDownloadWorker(DownloadStates states, DownloadRequest downloadRequest, CancellationToken cancellationToken = default) {
+    /// <summary>
+    /// 用于分块下载的工作线程。
+    /// (english) Multi part download worker.
+    /// </summary>
+    private async Task MultipartDownloadWorker(DownloadStates states, DownloadRequest downloadRequest, CancellationToken cancellationToken = default)
+    {
         using var fileStream = new FileStream(states.LocalPath, FileMode.Open, FileAccess.Write, FileShare.Write);
 
-        byte[] downloadBufferArr = ArrayPool<byte>.Shared.Rent(DOWNLOAD_BUFFER_SIZE);
-        Memory<byte> downloadBuffer = downloadBufferArr.AsMemory(0, DOWNLOAD_BUFFER_SIZE);
+        byte[] downloadBufferArr = ArrayPool<byte>.Shared.Rent(DEFAULT_DOWNLOAD_BUFFER_SIZE);
+        Memory<byte> downloadBuffer = downloadBufferArr.AsMemory(0, DEFAULT_DOWNLOAD_BUFFER_SIZE);
 
-        while (states.NextChunk() is (long start, long end)) {
+        while (states.NextChunk() is (long start, long end))
+        {
             fileStream.Seek(start, SeekOrigin.Begin);
 
             var response = await FlurlClient.Request(states.Url)
                 .WithHeader("Range", $"bytes={start}-{end}")
-                .GetAsync(cancellationToken: cancellationToken);
+                .GetAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
             response.ResponseMessage.EnsureSuccessStatusCode();
 
-            using var contentStream = await response.GetStreamAsync();
-            await WriteStreamToFile(contentStream, fileStream, downloadBuffer, downloadRequest, cancellationToken);
+            using var contentStream = await response.GetStreamAsync().ConfigureAwait(false);
+            await WriteStreamToFile(contentStream, fileStream, downloadBuffer, downloadRequest, cancellationToken).ConfigureAwait(false);
         }
 
         ArrayPool<byte>.Shared.Return(downloadBufferArr);
     }
 
-    private async Task DownloadFileInGroupAsync(DownloadRequest request, GroupDownloadRequest groupRequest, ConcurrentDictionary<DownloadRequest, DownloadResult> failed, CancellationToken cancellationToken) {
-        DownloadResult result = await DownloadFileAsync(request, cancellationToken);
+    /// <summary>
+    /// 将流写入文件。
+    /// (english) Write stream into file.
+    /// </summary>
+    private async Task WriteStreamToFile(Stream contentStream, FileStream fileStream, Memory<byte> buffer, DownloadRequest request, CancellationToken cancellationToken = default)
+    {
+        int bytesRead;
+        while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            await fileStream.WriteAsync(buffer[0..bytesRead], cancellationToken).ConfigureAwait(false);
+            request.BytesDownloaded?.Invoke(bytesRead);
+        }
+    }
+
+    /// <summary>
+    /// 批量下载中的单个文件下载任务。
+    /// (english) 
+    /// </summary>
+    private async Task DownloadFileInGroupAsync(DownloadRequest request, GroupDownloadRequest groupRequest, ConcurrentDictionary<DownloadRequest, DownloadResult> failed, CancellationToken cancellationToken)
+    {
+        DownloadResult result = await DownloadFileAsync(request, cancellationToken).ConfigureAwait(false);
         if (result.Type == DownloadResultType.Failed)
             failed.TryAdd(request, result);
 

--- a/MinecraftLaunch/Components/Downloader/MinecraftResourceDownloader.cs
+++ b/MinecraftLaunch/Components/Downloader/MinecraftResourceDownloader.cs
@@ -28,7 +28,8 @@ public sealed class MinecraftResourceDownloader {
         _downloader = new(maxThread);
     }
 
-    public async Task<GroupDownloadResult> VerifyAndDownloadDependenciesAsync(int fileVerificationParallelism = 10, CancellationToken cancellationToken = default) {
+    public async Task<GroupDownloadResult> VerifyAndDownloadDependenciesAsync(int fileVerificationParallelism = 10, CancellationToken cancellationToken = default)
+    {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(fileVerificationParallelism);
 
         #region 1.1 Libraries & Inherited Libraries
@@ -39,7 +40,8 @@ public sealed class MinecraftResourceDownloader {
 
         if (AllowInheritedDependencies
             && _entry is ModifiedMinecraftEntry modInstance
-            && modInstance.HasInheritance) {
+            && modInstance.HasInheritance)
+        {
             (libs, nativeLibs) = modInstance.InheritedMinecraft.GetRequiredLibraries();
             _dependencies.AddRange(libs);
             _dependencies.AddRange(nativeLibs);
@@ -50,7 +52,8 @@ public sealed class MinecraftResourceDownloader {
         #region 1.2 Client.jar
 
         var jar = _entry.GetJarElement();
-        if (jar != null) {
+        if (jar != null)
+        {
             _dependencies.Add(jar);
         }
 
@@ -58,74 +61,91 @@ public sealed class MinecraftResourceDownloader {
 
         #region 1.3 AssetIndex & Assets
 
-        if (AllowVerifyAssets) {
+        if (AllowVerifyAssets)
+        {
             var assetIndex = _entry.GetAssetIndex();
 
-            if (!VerifyDependency(assetIndex, cancellationToken)) {
+            // 验证 AssetIndex 文件
+            if (!VerifyDependency(assetIndex, cancellationToken))
+            {
                 var result = await _downloader
                     .DownloadFileAsync(new(assetIndex.Url, assetIndex.FullPath), cancellationToken);
 
-                if (result.Type == DownloadResultType.Failed) {
+                if (result.Type == DownloadResultType.Failed)
+                {
                     throw new Exception("Failed to obtain the dependent material index file");
                 }
             }
 
+            // 添加资源文件到依赖列表
             _dependencies.AddRange(_entry.GetRequiredAssets());
         }
 
         #endregion
 
-        // 2. Verify dependencies
-        SemaphoreSlim semaphore = new(fileVerificationParallelism, fileVerificationParallelism);
-        ConcurrentBag<MinecraftDependency> invalidDeps = [];
+        // 2. 验证依赖项
+        ConcurrentBag<MinecraftDependency> invalidDeps = new();
+        Parallel.ForEach(_dependencies, new ParallelOptions { MaxDegreeOfParallelism = fileVerificationParallelism }, dep => {
+            if (!VerifyDependency(dep, cancellationToken))
+            {
+                invalidDeps.Add(dep);
+            }
+        });
 
-        _dependencies.AsParallel()
-            .Where(x => {
-                if (!VerifyDependency(x, cancellationToken)) {
-                    return true;
-                }
-
-                return false;
-            })
-            .ForAll(invalidDeps.Add);
-
-        //var tasks = _dependencies.Select(async dep => {
-        //    await semaphore.WaitAsync(cancellationToken);
-        //    try {
-        //        if (!await VerifyDependency(dep, cancellationToken)) {
-        //            lock (invalidDeps) {
-        //                invalidDeps.Add(dep);
-        //            }
-        //        }
-        //    } finally {
-        //        semaphore.Release();
-        //    }
-        //}).ToList();
-
-        //await Task.WhenAll(tasks);
-
-        // 3. Download invalid dependencies
+        // 3. 下载无效的依赖项
         TotalCount = invalidDeps.Count;
-        var downloadItems = invalidDeps.Where(dep => dep is IDownloadDependency)
+        var downloadItems = invalidDeps
             .OfType<IDownloadDependency>()
-            .Select(dep => new DownloadRequest(dep.Url, dep.FullPath));
+            .Select(dep => new DownloadRequest(dep.Url, dep.FullPath))
+            .ToList();
 
         int currentCount = 0;
-        double speed = default;
-        int totalCount = downloadItems.Count();
+        double speed = 0;
+        int totalCount = downloadItems.Count;
+
         var groupRequest = new GroupDownloadRequest(downloadItems);
         groupRequest.DownloadSpeedChanged += arg => speed = arg;
 
         groupRequest.SingleRequestCompleted += (request, result) => {
             Interlocked.Increment(ref currentCount);
-            ProgressChanged?.Invoke(this, new ResourceDownloadProgressChangedEventArgs {
+            ProgressChanged?.Invoke(this, new ResourceDownloadProgressChangedEventArgs
+            {
                 Speed = speed,
                 TotalCount = totalCount,
                 CompletedCount = currentCount,
             });
         };
 
-        return await _downloader.DownloadFilesAsync(groupRequest, cancellationToken);
+        // 增加下载失败的重试机制
+        GroupDownloadResult downloadResult = await _downloader.DownloadFilesAsync(groupRequest, cancellationToken);
+        if (downloadResult.Type == DownloadResultType.Failed && downloadResult.Failed.Count > 0)
+        {
+            var failedItems = downloadResult.Failed.Keys
+                .Select(req => new DownloadRequest(req.Url, req.FileInfo.FullName))
+                .ToList();
+
+            var retryRequest = new GroupDownloadRequest(failedItems);
+            retryRequest.DownloadSpeedChanged += arg => speed = arg;
+
+            retryRequest.SingleRequestCompleted += (request, result) => {
+                Interlocked.Increment(ref currentCount);
+                ProgressChanged?.Invoke(this, new ResourceDownloadProgressChangedEventArgs
+                {
+                    Speed = speed,
+                    TotalCount = totalCount,
+                    CompletedCount = currentCount,
+                });
+            };
+
+            // 重试下载失败的文件
+            var retryResult = await _downloader.DownloadFilesAsync(retryRequest, cancellationToken);
+            if (retryResult.Type == DownloadResultType.Failed)
+            {
+                throw new Exception("Some dependencies failed to download after retrying.");
+            }
+        }
+
+        return downloadResult;
     }
 
     #region Privates

--- a/MinecraftLaunch/MinecraftLaunch.csproj
+++ b/MinecraftLaunch/MinecraftLaunch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>4.0.1-preview05</Version>
+		<Version>4.0.1-preview06</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
文件补全：
•       Parallel.ForEach 替代 AsParallel，设置最大并行度为 fileVerificationParallelism
•	无效依赖项会被直接添加到线程安全的 ConcurrentBag。
•	若第一次下载失败，提取失败的文件将重新尝试下载。
•	若重试后仍有失败的文件，则抛出异常。
•	实时更新进度和下载速度。
•	移除了注释掉的旧代码（如 SemaphoreSlim 的验证逻辑）。
•	将下载逻辑封装。
下载器部分就懒得继续叙述了，没改多少