### PR TITLE
使用JsonDocument API与流式读取/写入优化GC开销 #1

### DIFF
--- a/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
+++ b/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
@@ -111,8 +111,11 @@ public abstract class MinecraftEntry {
         List<MinecraftLibrary> libs = [];
         List<MinecraftLibrary> nativeLibs = [];
 
-        var libNodes = JsonNode.Parse(File.ReadAllText(ClientJsonPath))?["libraries"]?
-            .Deserialize(LibraryEntriesContext.Default.IEnumerableLibraryEntry)
+        using var stream =  File.OpenRead(ClientJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+        var root = doc.RootElement;
+        if(!root.TryGetProperty("libraries"u8,out var librariesElement))throw new InvalidDataException("client.json does not contain library information");
+        var libNodes = librariesElement.Deserialize(LibraryEntriesContext.Default.IEnumerableLibraryEntry)
                 ?? throw new InvalidDataException("client.json does not contain library information");
 
         foreach (var libNode in libNodes) {
@@ -120,7 +123,7 @@ public abstract class MinecraftEntry {
                 continue;
 
             // Check if a library is enabled
-            if (libNode.Rules is IEnumerable<RuleEntry> libRules) {
+            if (libNode.Rules is { } libRules) {
                 if (!IsLibraryEnabled(libRules))
                     continue;
             }

--- a/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
+++ b/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
@@ -81,6 +81,7 @@ public abstract class MinecraftEntry {
             assetIndexJsonPath = instance.InheritedMinecraft.AssetIndexJsonPath;
 
         // Parse asset index json
+        // TODO USE DOM
         JsonNode jsonNode = JsonNode.Parse(File.ReadAllText(assetIndexJsonPath));
         Dictionary<string, AssetJsonEntry> assets = jsonNode?["objects"]?
             .Deserialize(AssetJsonEntryContext.Default.DictionaryStringAssetJsonEntry)
@@ -99,7 +100,7 @@ public abstract class MinecraftEntry {
             };
         }
     }
-
+    // TODO  USE DOM
     public (IEnumerable<MinecraftLibrary> Libraries, IEnumerable<MinecraftLibrary> NativeLibraries) GetRequiredLibraries() {
         List<MinecraftLibrary> libs = [];
         List<MinecraftLibrary> nativeLibs = [];
@@ -237,7 +238,7 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
             throw new InvalidDataException("Invalid library name");
 
         if (libNode.NativeClassifierNames is not null)
-            libNode.MavenName += ":" + libNode.NativeClassifierNames[EnvironmentUtil.GetPlatformName()].Replace("${arch}", EnvironmentUtil.Arch);
+            libNode.MavenName += ":" + libNode.NativeClassifierNames[EnvironmentUtil.GetPlatformName()].Replace("${arch}", EnvironmentUtil.Arch,StringComparison.Ordinal);
 
         if (libNode.DownloadInformation != null) {
             DownloadArtifactEntry artifactNode = GetLibraryArtifactInfo(libNode);
@@ -246,7 +247,7 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
 
             #region Vanilla Pattern
 
-            if (artifactNode.Url.StartsWith("https://libraries.minecraft.net/")) {
+            if (artifactNode.Url.StartsWith("https://libraries.minecraft.net/", StringComparison.Ordinal)) {
                 return new VanillaLibrary(libNode.MavenName) {
                     MinecraftFolderPath = minecraftFolderPath,
                     Sha1 = artifactNode.Sha1,
@@ -258,8 +259,8 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
             #endregion
 
             #region Forge Pattern
-
-            if (artifactNode.Url.StartsWith("https://maven.minecraftforge.net/")) {
+            
+            if (artifactNode.Url.StartsWith("https://maven.minecraftforge.net/", StringComparison.Ordinal)) {
                 return new ForgeLibrary(libNode.MavenName) {
                     MinecraftFolderPath = minecraftFolderPath,
                     Sha1 = artifactNode.Sha1,
@@ -273,7 +274,7 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
 
             #region NeoForge Pattern
 
-            if (artifactNode.Url.StartsWith("https://maven.neoforged.net/")) {
+            if (artifactNode.Url.StartsWith("https://maven.neoforged.net/", StringComparison.Ordinal)) {
                 return new NeoForgeLibrary(libNode.MavenName) {
                     MinecraftFolderPath = minecraftFolderPath,
                     Sha1 = artifactNode.Sha1,
@@ -288,8 +289,8 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
 
         #region Other Patterns
 
-        if (libNode.MavenName.StartsWith("net.minecraft:launchwrapper")) {
-            return new DownloadableDependency(libNode.MavenName, $"https://libraries.minecraft.net/{GetLibraryPath(libNode.MavenName).Replace("\\", "/")}") {
+        if (libNode.MavenName.StartsWith("net.minecraft:launchwrapper", StringComparison.Ordinal)) {
+            return new DownloadableDependency(libNode.MavenName, $"https://libraries.minecraft.net/{GetLibraryPath(libNode.MavenName).Replace('\\', '/')}") {
                 MinecraftFolderPath = minecraftFolderPath,
                 IsNativeLibrary = libNode.NativeClassifierNames is not null
             };

--- a/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
+++ b/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
@@ -81,11 +81,17 @@ public abstract class MinecraftEntry {
             assetIndexJsonPath = instance.InheritedMinecraft.AssetIndexJsonPath;
 
         // Parse asset index json
-        // TODO USE DOM
-        JsonNode jsonNode = JsonNode.Parse(File.ReadAllText(assetIndexJsonPath));
-        Dictionary<string, AssetJsonEntry> assets = jsonNode?["objects"]?
-            .Deserialize(AssetJsonEntryContext.Default.DictionaryStringAssetJsonEntry)
-            ?? throw new InvalidDataException("Error in parsing asset index json file");
+        Dictionary<string, AssetJsonEntry> assets;
+        // 这里不用using表达式语法是为了在yield前释放资源,防止被挂起导致池化内存压力增大
+        using (var stream = File.OpenRead(assetIndexJsonPath))
+        using (var doc = JsonDocument.Parse(stream))
+        {
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("objects"u8, out var value))
+                throw new InvalidDataException("Error in parsing asset index json file");
+            assets = value.Deserialize(AssetJsonEntryContext.Default.DictionaryStringAssetJsonEntry)
+                     ?? throw new InvalidDataException("Error in parsing asset index json file");
+        }
 
         // Parse GameAsset objects
         foreach (var (key, assetJsonNode) in assets) {
@@ -100,7 +106,7 @@ public abstract class MinecraftEntry {
             };
         }
     }
-    // TODO  USE DOM
+    
     public (IEnumerable<MinecraftLibrary> Libraries, IEnumerable<MinecraftLibrary> NativeLibraries) GetRequiredLibraries() {
         List<MinecraftLibrary> libs = [];
         List<MinecraftLibrary> nativeLibs = [];

--- a/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
+++ b/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
@@ -57,3 +57,7 @@ public record struct OptifineMinecraftLibrary {
 [JsonSerializable(typeof(MinecraftJsonEntry))]
 [JsonSerializable(typeof(OptifineMinecraftEntry))]
 public sealed partial class MinecraftJsonEntryContext : JsonSerializerContext;
+
+[JsonSerializable(typeof(JsonDocument))]
+[JsonSerializable(typeof(JsonElement))]
+public sealed partial class JsonDocumentSerializeContext: JsonSerializerContext;

--- a/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
+++ b/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MinecraftLaunch.Base.Interfaces;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -20,10 +21,11 @@ public record MinecraftJsonEntry {
     [JsonPropertyName("type")] public string Type { get; set; }
     [JsonPropertyName("assets")] public string Assets { get; set; }
     [JsonPropertyName("mainClass")] public string MainClass { get; set; }
-    [JsonPropertyName("arguments")] public JsonNode Arguments { get; set; }
-    [JsonPropertyName("libraries")] public JsonArray Libraries { get; set; }
+    [JsonPropertyName("arguments")] public JsonElement Arguments { get; set; }
+    /// <summary> ValueType is Array </summary>
+    [JsonPropertyName("libraries")] public JsonElement Libraries { get; set; }
     [JsonPropertyName("inheritsFrom")] public string InheritsFrom { get; set; }
-    [JsonPropertyName("javaVersion")] public JsonNode JavaVersion { get; set; }
+    [JsonPropertyName("javaVersion")] public JsonElement JavaVersion { get; set; }
     [JsonPropertyName("releaseTime")] public DateTime ReleaseTime { get; set; }
     [JsonPropertyName("assetIndex")] public AssstIndexJsonEntry AssetIndex { get; set; }
     [JsonPropertyName("minecraftArguments")] public string MinecraftArguments { get; set; }

--- a/MinecraftLaunch.Base/Models/Network/CurseforgeModpackInstallEntry.cs
+++ b/MinecraftLaunch.Base/Models/Network/CurseforgeModpackInstallEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
@@ -14,12 +15,12 @@ public record CurseforgeModpackInstallEntry {
 
     [JsonIgnore] public string McVersion => Minecraft.McVersion;
     [JsonIgnore] public bool IsOverride => Overrides is "overrides";
-    [JsonIgnore] public string PrimaryModLoader => Minecraft.ModLoaders?.FirstOrDefault()?["id"]?.GetValue<string>().Split("-")?.First();
+    [JsonIgnore] public string PrimaryModLoader => Minecraft.ModLoaders.GetArrayLength() >=0 ? Minecraft.ModLoaders[0].GetString()!.Split("-")?.First() : null;
 }
 
 public record CurseforgeModpackMinecraftEntry {
     [JsonPropertyName("version")] public string McVersion { get; set; }
-    [JsonPropertyName("modLoaders")] public IEnumerable<JsonNode> ModLoaders { get; set; }
+    [JsonPropertyName("modLoaders")] public /*Array*/ JsonElement ModLoaders { get; set; }
 }
 
 public record CurseforgeModpackFileEntry {

--- a/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
+++ b/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
@@ -201,7 +201,7 @@ public sealed class MicrosoftAuthenticator {
         {
             using var profileNode = await JsonDocument.ParseAsync(await profileRes.GetStreamAsync(),
                 cancellationToken: cancellationToken);
-            return new MicrosoftAccount(profileNode.RootElement.GetProperty("name"u8).GetString(), Guid.Parse(profileNode.RootElement.GetProperty("id"u8).GetString()!), accessToken, refreshToken, DateTime.Now);
+            return new MicrosoftAccount(profileNode.RootElement.GetProperty("name"u8).GetString(), profileNode.RootElement.GetProperty("id"u8).GetGuid(), accessToken, refreshToken, DateTime.Now);
         }
         catch (Exception e)
         {

--- a/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
+++ b/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
@@ -5,10 +5,7 @@ using MinecraftLaunch.Extensions;
 using MinecraftLaunch.Utilities;
 using System.Diagnostics;
 using System.Net.Http.Json;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Web;
 
 namespace MinecraftLaunch.Components.Authenticator;
 
@@ -115,7 +112,7 @@ public sealed class MicrosoftAuthenticator {
                 };
             }
 
-            if (tempTokenResponse.GetProperty("token_type"u8).GetString() is "Bearer")
+            if (tempTokenResponse.GetPropertyNullable("token_type"u8)?.GetString() is "Bearer")
                 return tokenResponse;
 
             await Task.Delay(TimeSpan.FromSeconds(codeResponse.Interval), cancellationToken);

--- a/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
+++ b/MinecraftLaunch/Components/Authenticator/MicrosoftAuthenticator.cs
@@ -6,6 +6,7 @@ using MinecraftLaunch.Utilities;
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Web;
 
@@ -43,20 +44,19 @@ public sealed class MicrosoftAuthenticator {
     /// Asynchronously authenticates the Microsoft account.
     /// </summary>
     /// <returns>A ValueTask that represents the asynchronous operation. The task result contains the authenticated Microsoft account.</returns>
-    public async Task<MicrosoftAccount> AuthenticateAsync(OAuth2TokenResponse oAuth2Token, CancellationToken cancellationToken = default) {
-        try {
-            if (oAuth2Token is null)
-                ArgumentException.ThrowIfNullOrEmpty(nameof(oAuth2Token));
+    public async Task<MicrosoftAccount> AuthenticateAsync(OAuth2TokenResponse oAuth2Token,
+        CancellationToken cancellationToken = default)
+    {
+        if (oAuth2Token is null)
+            ArgumentException.ThrowIfNullOrEmpty(nameof(oAuth2Token));
 
-            var xblToken = await GetXBLTokenAsync(oAuth2Token.AccessToken, cancellationToken);
-            var xsts = await GetXSTSTokenAsync(xblToken, cancellationToken);
-            var minecraftAccessToken = await GetMinecraftAccessTokenAsync((xblToken, xsts), cancellationToken);
-            var profile = await GetMinecraftProfileAsync(minecraftAccessToken.GetString("access_token"), oAuth2Token.RefreshToken, cancellationToken);
+        using var xblToken = await GetXBLTokenAsync(oAuth2Token.AccessToken, cancellationToken);
+        using var xsts = await GetXSTSTokenAsync(xblToken.RootElement, cancellationToken);
+        using var minecraftAccessToken = await GetMinecraftAccessTokenAsync((xblToken.RootElement, xsts.RootElement), cancellationToken);
+        var profile = await GetMinecraftProfileAsync(minecraftAccessToken.RootElement.GetProperty("access_token"u8).GetString(),
+            oAuth2Token.RefreshToken, cancellationToken);
 
-            return profile;
-        } catch (Exception) {
-            throw;
-        }
+        return profile;
     }
 
     /// <summary>
@@ -103,18 +103,19 @@ public sealed class MicrosoftAuthenticator {
                     ["device_code"] = codeResponse.DeviceCode
                 }, HttpCompletionOption.ResponseContentRead, cancellationToken);
 
-            var tokenJson = await response.GetStringAsync();
-            var tempTokenResponse = tokenJson.AsNode();
+            await using var tokenJson = await response.GetStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(tokenJson,cancellationToken: cancellationToken); 
+            var tempTokenResponse = doc.RootElement;
 
-            if (tempTokenResponse["error"] == null) {
+            if (!tempTokenResponse.TryGetProperty("error"u8,out _)) {
                 tokenResponse = new() {
-                    AccessToken = tempTokenResponse.GetString("access_token"),
-                    RefreshToken = tempTokenResponse.GetString("refresh_token"),
-                    ExpiresIn = tempTokenResponse.GetInt32("expires_in"),
+                    AccessToken = tempTokenResponse.GetProperty("access_token"u8).GetString(),
+                    RefreshToken = tempTokenResponse.GetProperty("refresh_token"u8).GetString(),
+                    ExpiresIn = tempTokenResponse.GetProperty("expires_in"u8).GetInt32(),
                 };
             }
 
-            if (tempTokenResponse.GetString("token_type") is "Bearer")
+            if (tempTokenResponse.GetProperty("token_type"u8).GetString() is "Bearer")
                 return tokenResponse;
 
             await Task.Delay(TimeSpan.FromSeconds(codeResponse.Interval), cancellationToken);
@@ -128,7 +129,7 @@ public sealed class MicrosoftAuthenticator {
     /// <summary>
     /// Get Xbox live token & userhash
     /// </summary>
-    private static async Task<JsonNode> GetXBLTokenAsync(string token, CancellationToken cancellationToken = default) {
+    private static async Task</*所有权*/JsonDocument> GetXBLTokenAsync(string token, CancellationToken cancellationToken = default) {
         var request = HttpUtil.Request("https://user.auth.xboxlive.com/user/authenticate");
         var xblContent = new XBLTokenPayload {
             Properties = new XBLProperties {
@@ -143,7 +144,7 @@ public sealed class MicrosoftAuthenticator {
         using var xblJsonReq = await request.PostAsync(JsonContent.Create(xblContent,
             MicrosoftRequestPayloadContext.Default.XBLTokenPayload), cancellationToken: cancellationToken);
 
-        return (await xblJsonReq.GetStringAsync()).AsNode();
+        return await JsonDocument.ParseAsync(await xblJsonReq.GetStreamAsync(),cancellationToken:cancellationToken);
     }
 
     /// <summary>
@@ -151,12 +152,12 @@ public sealed class MicrosoftAuthenticator {
     /// </summary>
     /// <returns></returns>
     /// <exception cref="FailedAuthenticationException"></exception>
-    private static async Task<JsonNode> GetXSTSTokenAsync(JsonNode xblTokenNode, CancellationToken cancellationToken = default) {
+    private static async Task</*所有权*/JsonDocument> GetXSTSTokenAsync(JsonElement xblTokenNode, CancellationToken cancellationToken = default) {
         var request = HttpUtil.Request("https://xsts.auth.xboxlive.com/xsts/authorize");
         var xstsContent = new XSTSTokenPayload {
             Properties = new XSTSProperties {
                 SandboxId = "RETAIL",
-                UserTokens = [xblTokenNode.GetString("Token")]
+                UserTokens = [xblTokenNode.GetProperty("Token"u8).GetString()]
             },
             RelyingParty = "rp://api.minecraftservices.com/",
             TokenType = "JWT"
@@ -165,25 +166,27 @@ public sealed class MicrosoftAuthenticator {
         using var xstsJsonReq = await request.PostAsync(JsonContent.Create(xstsContent,
             MicrosoftRequestPayloadContext.Default.XSTSTokenPayload), cancellationToken: cancellationToken);
 
-        return (await xstsJsonReq.GetStringAsync()).AsNode();
+        return await JsonDocument.ParseAsync(await xstsJsonReq.GetStreamAsync(),cancellationToken:cancellationToken);
     }
 
     /// <summary>
     /// Get Minecraft access token
     /// </summary>
-    private static async Task<JsonNode> GetMinecraftAccessTokenAsync((JsonNode xblTokenNode, JsonNode xstsTokenNode) nodes, CancellationToken cancellationToken = default) {
+    private static async Task</*所有权*/JsonDocument> GetMinecraftAccessTokenAsync((JsonElement xblTokenNode, JsonElement xstsTokenNode) nodes, CancellationToken cancellationToken = default) {
         var request = HttpUtil.Request("https://api.minecraftservices.com/authentication/login_with_xbox");
-        var xstsToken = nodes.xstsTokenNode.GetString("Token");
-        var uhsToken = nodes.xblTokenNode.Select("DisplayClaims")
-            .GetEnumerable("xui")
-            .FirstOrDefault()
-            .GetString("uhs");
+        var xstsToken = nodes.xstsTokenNode.GetProperty("Token"u8).GetString();
+        var uhsToken = nodes.xblTokenNode
+            .GetProperty("DisplayClaims"u8)
+            .GetProperty("xui"u8)
+            [0]//get first
+            .GetProperty("uhs"u8)
+            .GetString();
 
         var payload = new MinecraftPayload($"XBL3.0 x={uhsToken};{xstsToken}");
         using var mcTokenReq = await request.PostAsync(JsonContent.Create(payload,
             MicrosoftRequestPayloadContext.Default.MinecraftPayload), cancellationToken: cancellationToken);
 
-        return (await mcTokenReq.GetStringAsync()).AsNode();
+        return await JsonDocument.ParseAsync(await mcTokenReq.GetStreamAsync(),cancellationToken:cancellationToken);
     }
 
     /// <summary>
@@ -197,12 +200,16 @@ public sealed class MicrosoftAuthenticator {
             .WithHeader("Authorization", $"Bearer {accessToken}");
 
         using var profileRes = await request.GetAsync(cancellationToken: cancellationToken);
-        var profileNode = (await profileRes.GetStringAsync())
-            .AsNode();
-
-        return profileNode == null
-            ? throw new InvalidOperationException("Failed to retrieve Minecraft profile")
-            : new MicrosoftAccount(profileNode.GetString("name"), Guid.Parse(profileNode.GetString("id")), accessToken, refreshToken, DateTime.Now);
+        try
+        {
+            using var profileNode = await JsonDocument.ParseAsync(await profileRes.GetStreamAsync(),
+                cancellationToken: cancellationToken);
+            return new MicrosoftAccount(profileNode.RootElement.GetProperty("name"u8).GetString(), Guid.Parse(profileNode.RootElement.GetProperty("id"u8).GetString()!), accessToken, refreshToken, DateTime.Now);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidOperationException("Failed to retrieve Minecraft profile", e);
+        }
     }
 
     #endregion

--- a/MinecraftLaunch/Components/Installer/FabricInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/FabricInstaller.cs
@@ -78,12 +78,13 @@ public sealed class FabricInstaller : InstallerBase {
         string requestUrl = $"https://meta.fabricmc.net/v2/versions/loader/{Entry.McVersion}/{Entry.BuildVersion}/profile/json";
         requestUrl = DownloadManager.BmclApi.TryFindUrl(requestUrl);
 
-        var json = await HttpUtil.FlurlClient.Request(requestUrl)
-            .GetStringAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
-
-        string instanceId = CustomId ??
-            json.AsNode().GetString("id") ??
-            $"fabric-loader-{Entry.Loader.Version}_{entry.Id}";
+        await using var jsonStream = await HttpUtil.FlurlClient.Request(requestUrl)
+            .GetStreamAsync(HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(jsonStream,cancellationToken:cancellationToken).ConfigureAwait(false);
+        
+        string instanceId = CustomId ?? 
+                            doc.RootElement.GetPropertyNullable("id"u8)?.GetString() ??
+                            $"fabric-loader-{Entry.Loader.Version}_{entry.Id}";
 
         var jsonFile = new FileInfo(Path
             .Combine(MinecraftFolder, "versions", instanceId, $"{instanceId}.json"));
@@ -91,8 +92,10 @@ public sealed class FabricInstaller : InstallerBase {
         if (!jsonFile.Directory!.Exists)
             jsonFile.Directory.Create();
 
-        await File.WriteAllTextAsync(jsonFile.FullName, json, cancellationToken);
-
+        await using var output = File.OpenWrite(jsonFile.FullName);
+        await JsonSerializer.SerializeAsync(output, doc, JsonDocumentSerializeContext.Default.JsonDocument,
+            cancellationToken);
+        
         ReportProgress(InstallStep.DownloadVersionJson, 0.45d, TaskStatus.Running, 1, 1);
         return jsonFile;
     }
@@ -115,7 +118,7 @@ public sealed class FabricInstaller : InstallerBase {
 
     private static ModifiedMinecraftEntry ParseModifiedMinecraft(FileInfo file, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
-        var entry = MinecraftParser.Parse(file.Directory, null, out var _) as ModifiedMinecraftEntry;
+        var entry = MinecraftParser.Parse(file.Directory, null, out  _) as ModifiedMinecraftEntry;
 
         return entry ?? throw new InvalidOperationException("An incorrect modified entry was encountered");
     }

--- a/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
@@ -177,9 +177,10 @@ public sealed class ForgeInstaller : InstallerBase {
                               ? installProfile.GetProperty("versionInfo"u8).GetString()
                               : packageArchive.GetEntry("version.json")?.ReadAsString())
                           ?? throw new Exception("Failed to read version.json");
+        // not TO DO,据测量这里的开销占比较小,不是很值得手写patch
         var jsonNode = JsonNode.Parse(jsonContent);
         
-
+        
         string entryId = CustomId ?? $"{Entry.McVersion}-{(Entry.IsNeoforge ? "neoforge" : "forge")}-{Entry.ForgeVersion}";
         var jsonFile = new FileInfo(Path.Combine(MinecraftFolder, "versions", entryId, $"{entryId}.json"));
 

--- a/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
@@ -138,12 +138,13 @@ public sealed class ForgeInstaller : InstallerBase {
         return packageFile;
     }
 
-    private (ZipArchive package, JsonDocument installProfile, bool isLegacy) ParseForgePackage(string packageFilePath, CancellationToken cancellationToken) {
+    private (ZipArchive package, /*注意需要释放*/ JsonDocument installProfile, bool isLegacy) ParseForgePackage(string packageFilePath, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         ReportProgress(InstallStep.ParsePackage, 0.45d, TaskStatus.Running, 1, 0);
 
         var packageArchive = ZipFile.OpenRead(packageFilePath);
         using var install_profile_json_stream = packageArchive.GetEntry("install_profile.json")?.Open()??throw new Exception("Failed to parse install_profile.json");
+        // 这里转交所有权,不释放
         var installProfileNode = JsonDocument.Parse(install_profile_json_stream);
         var isLegacyForgeVersion = installProfileNode.RootElement.TryGetProperty("install"u8,out _);
 

--- a/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/ForgeInstaller.cs
@@ -40,23 +40,31 @@ public sealed class ForgeInstaller : InstallerBase {
 
         ReportProgress(InstallStep.Started, 0.0d, TaskStatus.WaitingToRun, 1, 1);
 
-        try {
+        try
+        {
             inheritedEntry = ParseMinecraft(cancellationToken);
             forgePackageFile = await DownloadForgePackageAsync(cancellationToken);
 
             var (package, installProfile, isLegacy) = ParseForgePackage(forgePackageFile.FullName, cancellationToken);
-            var forgeClientFile = await WriteVersionJsonAndSomeDependenciesAsync(isLegacy, installProfile, package, cancellationToken);
+            using(var doc = installProfile){
+                var forgeClientFile =
+                    await WriteVersionJsonAndSomeDependenciesAsync(isLegacy, doc.RootElement, package,
+                        cancellationToken);
 
-            entry = ParseModifiedMinecraft(forgeClientFile, cancellationToken);
-            await CompleteForgeDependenciesAsync(isLegacy, installProfile, entry, cancellationToken);
+                entry = ParseModifiedMinecraft(forgeClientFile, cancellationToken);
+                await CompleteForgeDependenciesAsync(isLegacy, doc.RootElement, entry, cancellationToken);
 
-            if (!isLegacy) {
-                await RunInstallProcessorAsync(forgePackageFile.FullName, installProfile, entry, cancellationToken);
+                if (!isLegacy)
+                {
+                    await RunInstallProcessorAsync(forgePackageFile.FullName, doc.RootElement, entry, cancellationToken);
+                }
             }
 
             ReportProgress(InstallStep.RanToCompletion, 1.0d, TaskStatus.RanToCompletion, 1, 1);
             ReportCompleted(true);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             ReportProgress(InstallStep.Interrupted, 1.0d, TaskStatus.Canceled, 1, 1);
             ReportCompleted(false, ex);
         }
@@ -130,50 +138,46 @@ public sealed class ForgeInstaller : InstallerBase {
         return packageFile;
     }
 
-    private (ZipArchive package, JsonNode installProfile, bool isLegacy) ParseForgePackage(string packageFilePath, CancellationToken cancellationToken) {
+    private (ZipArchive package, JsonDocument installProfile, bool isLegacy) ParseForgePackage(string packageFilePath, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         ReportProgress(InstallStep.ParsePackage, 0.45d, TaskStatus.Running, 1, 0);
 
         var packageArchive = ZipFile.OpenRead(packageFilePath);
-        var installProfileNode = packageArchive
-            .GetEntry("install_profile.json")
-            ?.ReadAsString()
-            .AsNode()
-            ?? throw new Exception("Failed to parse install_profile.json");
-
-        bool isLegacyForgeVersion = installProfileNode.Select("install") != null;
+        using var install_profile_json_stream = packageArchive.GetEntry("install_profile.json")?.Open()??throw new Exception("Failed to parse install_profile.json");
+        var installProfileNode = JsonDocument.Parse(install_profile_json_stream);
+        var isLegacyForgeVersion = installProfileNode.RootElement.TryGetProperty("install"u8,out _);
 
         ReportProgress(InstallStep.ParsePackage, 0.50d, TaskStatus.Running, 1, 1);
         return (packageArchive, installProfileNode, isLegacyForgeVersion);
     }
 
-    private async Task<FileInfo> WriteVersionJsonAndSomeDependenciesAsync(bool isLegacyForgeVersion, JsonNode installProfile, ZipArchive packageArchive, CancellationToken cancellationToken) {
+    private async Task<FileInfo> WriteVersionJsonAndSomeDependenciesAsync(bool isLegacyForgeVersion, JsonElement installProfile, ZipArchive packageArchive, CancellationToken cancellationToken) {
         string forgeVersion = $"{Entry.McVersion}-{Entry.ForgeVersion}";
         string forgeLibsFolder = Path.Combine(MinecraftFolder, "libraries\\net\\minecraftforge\\forge", forgeVersion);
 
         ReportProgress(InstallStep.WriteVersionJsonAndSomeDependencies, 0.50d, TaskStatus.Running, 1, 0);
 
         if (isLegacyForgeVersion) {
-            var universalFilePath = installProfile.Select("install").GetString("filePath")
-                ?? throw new InvalidDataException("Unable to resolve location of universal file in archive");
-
-            var universalFileEntry = packageArchive.GetEntry(universalFilePath)
+            if(!installProfile.GetProperty("install"u8).TryGetProperty("filePath"u8,out var filePath))throw new InvalidDataException("Unable to resolve location of universal file in archive");
+            
+            var universalFileEntry = packageArchive.GetEntry(filePath.GetString()!)
                 ?? throw new FileNotFoundException("The universal file was not found in the archive");
 
-            universalFileEntry.ExtractTo(Path.Combine(forgeLibsFolder, universalFileEntry.Name.Replace("-universal", string.Empty)));
+            universalFileEntry.ExtractTo(Path.Combine(forgeLibsFolder, universalFileEntry.Name.Replace("-universal", string.Empty,StringComparison.Ordinal)));
         }
 
         if (packageArchive.GetEntry($"maven/net/minecraftforge/forge/{forgeVersion}/") != null)
-            foreach (var entry in packageArchive.Entries.Where(x => !x.FullName.EndsWith('/') && x.FullName.StartsWith($"maven/net/minecraftforge/forge/{forgeVersion}")))
+            foreach (var entry in packageArchive.Entries.Where(x => !x.FullName.EndsWith('/') && x.FullName.StartsWith($"maven/net/minecraftforge/forge/{forgeVersion}", StringComparison.Ordinal)))
                 entry.ExtractTo(Path.Combine(forgeLibsFolder, entry.Name));
 
         packageArchive.GetEntry("data/client.lzma")?.ExtractTo(Path.Combine(forgeLibsFolder, $"forge-{forgeVersion}-clientdata.lzma"));
-
-        string jsonContent = (isLegacyForgeVersion
-            ? installProfile.Select("versionInfo")!.ToString()
-            : packageArchive.GetEntry("version.json")?.ReadAsString())
-            ?? throw new Exception("Failed to read version.json");
+        
+        var jsonContent = (isLegacyForgeVersion
+                              ? installProfile.GetProperty("versionInfo"u8).GetString()
+                              : packageArchive.GetEntry("version.json")?.ReadAsString())
+                          ?? throw new Exception("Failed to read version.json");
         var jsonNode = JsonNode.Parse(jsonContent);
+        
 
         string entryId = CustomId ?? $"{Entry.McVersion}-{(Entry.IsNeoforge ? "neoforge" : "forge")}-{Entry.ForgeVersion}";
         var jsonFile = new FileInfo(Path.Combine(MinecraftFolder, "versions", entryId, $"{entryId}.json"));
@@ -188,7 +192,7 @@ public sealed class ForgeInstaller : InstallerBase {
         return jsonFile;
     }
 
-    private async Task CompleteForgeDependenciesAsync(bool isLegacyForgeVersion, JsonNode installProfile, MinecraftEntry minecraft, CancellationToken cancellationToken) {
+    private async Task CompleteForgeDependenciesAsync(bool isLegacyForgeVersion, JsonElement installProfile, MinecraftEntry minecraft, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         ReportProgress(InstallStep.DownloadLibraries, 0.50d, TaskStatus.Running, 1, 0);
 
@@ -203,7 +207,7 @@ public sealed class ForgeInstaller : InstallerBase {
         dependencies.AddRange(libraries);
 
         if (!isLegacyForgeVersion) {
-            var processorLibraries = installProfile.Select("libraries")
+            var processorLibraries = installProfile.GetProperty("libraries"u8)
                 .Deserialize(LibraryEntryContext.Default.IEnumerableLibraryEntry)?
                 .Select(lib => MinecraftLibrary.ParseJsonNode(lib, MinecraftFolder))
                 ?? throw new InvalidDataException();
@@ -227,11 +231,11 @@ public sealed class ForgeInstaller : InstallerBase {
         //    throw new InvalidOperationException("Some dependent files encountered errors during download");
     }
 
-    private async Task RunInstallProcessorAsync(string packageFilePath, JsonNode installProfile, MinecraftEntry entry, CancellationToken cancellationToken) {
+    private async Task RunInstallProcessorAsync(string packageFilePath, JsonElement installProfile, MinecraftEntry entry, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        Dictionary<string, Dictionary<string, string>> forgeDataDictionary = installProfile.Select("data")
-            .Deserialize(ForgeInstallerContext.Default.DictionaryStringDictionaryStringString)
+        Dictionary<string, Dictionary<string, string>> forgeDataDictionary = 
+            installProfile.GetProperty("data"u8).Deserialize(ForgeInstallerContext.Default.DictionaryStringDictionaryStringString)
             ?? throw new Exception("Failed to parse install profile data");
 
         string forgeVersion = $"{Entry.McVersion}-{Entry.ForgeVersion}";
@@ -259,8 +263,8 @@ public sealed class ForgeInstaller : InstallerBase {
                     .FormatLibraryNameToRelativePath())
                     .ToPath();
             });
-
-        var forgeProcessors = installProfile.Select("processors")?
+        if (!installProfile.TryGetProperty("processors"u8,out var processorsEntry)) throw new InvalidDataException("Unable to parse Forge Processors");
+        var forgeProcessors = processorsEntry
             .Deserialize(ForgeInstallerContext.Default.IEnumerableForgeProcessorData)?
             .Where(x => !(x.Sides.Count == 1 && x.Sides.Contains("server")))
             .ToArray()
@@ -314,13 +318,13 @@ public sealed class ForgeInstaller : InstallerBase {
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
             }) ?? throw new Exception("Failed to start Java");
-
-            List<string> _errorOutputs = [];
-
-            process.ErrorDataReceived += (_, args) => {
-                if (args.Data is string data && !string.IsNullOrEmpty(data))
-                    _errorOutputs.Add(args.Data);
-            };
+//            TODO Maybe it is Xilu's Todo event 
+//            List<string> _errorOutputs = [];
+//
+//            process.ErrorDataReceived += (_, arg) => {
+//                if (arg.Data is not null && !string.IsNullOrEmpty(arg.Data))
+//                    _errorOutputs.Add(arg.Data);
+//            };
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();

--- a/MinecraftLaunch/Components/Installer/JavaInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/JavaInstaller.cs
@@ -4,7 +4,6 @@ using MinecraftLaunch.Base.Enums;
 using MinecraftLaunch.Base.Models.Network;
 using MinecraftLaunch.Components.Downloader;
 using System.Diagnostics;
-using System.Text.Json.Nodes;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using MinecraftLaunch.Base.EventArgs;
@@ -71,36 +70,49 @@ public sealed class JavaInstaller {
     /// <param name="cancellationToken">取消令牌</param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
-    // TODO USE DOM
-    private async Task<JsonNode> FetchJavaInfoAsync(CancellationToken cancellationToken) {
+    private async Task<JsonElement> FetchJavaInfoAsync(CancellationToken cancellationToken) {
         ReportProgress(InstallStep.FetchingMetadata, 0.1d, TaskStatus.Running, 1, 0);
 
         string url = "https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json";
-        string json = await url.GetStringAsync(cancellationToken: cancellationToken); // 获取 Java 元数据
-
-        string platformKey = GetPlatformKey(); // 获取平台
-        var javaInfo = JsonNode.Parse(json)?[platformKey]?["java-runtime-gamma"]?.AsArray()
-            ?? throw new InvalidOperationException($"无法获取 Java 元数据，平台：{platformKey}"); // 意思：解析Json内容，如果不是数组就报错
-        if (javaInfo == null) {
-            throw new InvalidOperationException($"无法获取 Java 元数据，平台：{platformKey}");
-        }
+        await using var stream = await url.GetStreamAsync(cancellationToken:cancellationToken); // 获取 Java 元数据
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var root = doc.RootElement;
+        
+        var platformKey = GetPlatformKey(); // 获取平台
+        if(!root.TryGetProperty(platformKey,out var platformElement)||
+           !platformElement.TryGetProperty("java-runtime-gamma"u8,out var javaInfoElement)||
+           javaInfoElement.ValueKind is not JsonValueKind.Array)
+            throw new InvalidOperationException($"无法获取 Java 元数据，平台：{platformKey}"); // 意思：解析Json内容，如果不是数组就报错
+        
+        // 原逻辑没有判长度为0的条件
         ReportProgress(InstallStep.FetchingMetadata, 0.2d, TaskStatus.Running, 1, 1); // 汇报进度
-        return javaInfo;
+        // 此处无法进行所有权传递,Clone
+        return javaInfoElement.Clone();
     }
 
-    private async Task<FileInfo> DownloadJavaAsync(JsonNode javaInfo, CancellationToken cancellationToken) {
+    private async Task<FileInfo> DownloadJavaAsync(/*ArrayElement*/JsonElement javaInfo, CancellationToken cancellationToken) {
         ReportProgress(InstallStep.DownloadPackage, 0.3d, TaskStatus.Running, 1, 0); // 汇报进度
+        if (javaInfo.ValueKind != JsonValueKind.Array) throw new ArgumentException("value kind is not Array",nameof(javaInfo));
 
-        var javaUrl = javaInfo [0] ["manifest"]?["url"]?.ToString() // [0] 代表第一个元素，[""manifest"] 代表 manifest 属性
-            ?? javaInfo[0]["url"]?.ToString() // ["url"] 代表 url 属性
-            ?? throw new InvalidOperationException("无法解析 Java manifest 下载地址"); // 意思：如果没有这个地址就报错
+        JsonElement urlElement;
+        if (!(javaInfo[0].TryGetProperty("manifest"u8, out var manifestElement) &&
+             manifestElement.TryGetProperty("url"u8, out urlElement)
+            ) &&
+            !javaInfo[0].TryGetProperty("url"u8, out urlElement)) throw new InvalidOperationException("无法解析 Java manifest 下载地址");// 意思：如果没有这个地址就报错
 
         string fileName = Path.Combine(JavaFolder, "java-runtime-filelist.json"); // 拼接路径
-        var downloadRequest = new DownloadRequest(javaUrl, fileName){
-            Size = long.Parse(javaInfo[0]["manifest"]["size"].ToString())
+        var sizeElement = manifestElement.GetProperty("size"u8);
+        var url = urlElement.GetString();
+        var downloadRequest = new DownloadRequest(urlElement.GetString(), fileName){
+            Size = sizeElement.ValueKind switch
+            {
+                JsonValueKind.Number=>sizeElement.GetInt64(),
+                JsonValueKind.String=>long.Parse(sizeElement.GetString()!),
+                _=> throw new InvalidOperationException("意外的JSON数据:size")
+            }
         }; // 创建下载请求
 
-        Console.WriteLine(javaUrl);
+        Console.WriteLine(url);
 
         await new DefaultDownloader()
             .DownloadAsync(downloadRequest, cancellationToken); // 异步下载 manifest

--- a/MinecraftLaunch/Components/Installer/JavaInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/JavaInstaller.cs
@@ -127,15 +127,13 @@ public sealed class JavaInstaller {
             Directory.CreateDirectory(extractPath);
         await using var stream = File.OpenRead(manifestFile.FullName);
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-        var filesEnumerator = doc.RootElement.GetProperty("files"u8).EnumerateObject();
+        var filesEnumeratorElement = doc.RootElement.GetProperty("files"u8);
 
         int totalFiles = 0;
         // count total,filesEnumerator咋没暴露计数API(
-        while (!filesEnumerator.MoveNext()) ++totalFiles;
-        filesEnumerator.Dispose();
-        // reset,the iter is supported 
-        filesEnumerator.Reset();
-        
+        foreach (var i in filesEnumeratorElement.EnumerateObject()) totalFiles++;
+
+        var filesEnumerator = filesEnumeratorElement.EnumerateObject();
         
         int completedFiles = 0;
     

--- a/MinecraftLaunch/Components/Installer/JavaInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/JavaInstaller.cs
@@ -6,6 +6,7 @@ using MinecraftLaunch.Components.Downloader;
 using System.Diagnostics;
 using System.Text.Json.Nodes;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using MinecraftLaunch.Base.EventArgs;
 namespace MinecraftLaunch.Components.Installer;
 
@@ -70,6 +71,7 @@ public sealed class JavaInstaller {
     /// <param name="cancellationToken">取消令牌</param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
+    // TODO USE DOM
     private async Task<JsonNode> FetchJavaInfoAsync(CancellationToken cancellationToken) {
         ReportProgress(InstallStep.FetchingMetadata, 0.1d, TaskStatus.Running, 1, 0);
 
@@ -111,12 +113,18 @@ public sealed class JavaInstaller {
         string extractPath = Path.Combine(JavaFolder, "runtime");
         if (!Directory.Exists(extractPath))
             Directory.CreateDirectory(extractPath);
-    
-        var json = JsonNode.Parse(await File.ReadAllTextAsync(manifestFile.FullName, token).ConfigureAwait(false));
-        var files = json!["files"]!.AsObject();
-    
-        var entries = files.ToList();
-        int totalFiles = entries.Count;
+        await using var stream = File.OpenRead(manifestFile.FullName);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+        var filesEnumerator = doc.RootElement.GetProperty("files"u8).EnumerateObject();
+
+        int totalFiles = 0;
+        // count total,filesEnumerator咋没暴露计数API(
+        while (!filesEnumerator.MoveNext()) ++totalFiles;
+        filesEnumerator.Dispose();
+        // reset,the iter is supported 
+        filesEnumerator.Reset();
+        
+        
         int completedFiles = 0;
     
         // 并发数来自 DownloadManager
@@ -131,28 +139,31 @@ public sealed class JavaInstaller {
         var tasks = new List<Task>(totalFiles);
     
         long globalDownloadedBytes = 0;
-        var globalStopwatch = Stopwatch.StartNew();
+        var globalStopwatch = Stopwatch.GetTimestamp();
     
-        foreach (var kv in entries) {
-            var fileKey = kv.Key;
-            var fileNode = kv.Value!;
+        foreach (var property in filesEnumerator) {
+            var fileKey = property.Name;
+            var fileElement = property.Value;
     
             tasks.Add(Task.Run(async () => {
                 await semaphore.WaitAsync(token).ConfigureAwait(false);
                 try {
                     string filePath = Path.Combine(extractPath, fileKey);
-                    var fileInfo = fileNode.AsObject();
+                    
     
                     // 目录直接创建
-                    if (fileInfo["type"]?.ToString() == "directory") {
+                    if (fileElement.TryGetProperty("type"u8, out var value) && value.GetString() == "directory")
+                    {
                         Directory.CreateDirectory(filePath);
                         Interlocked.Increment(ref completedFiles);
                         ReportProgressWithSpeed();
                         return;
                     }
-    
-                    string url = fileInfo["downloads"]?["raw"]?["url"]?.ToString()
-                                 ?? throw new InvalidOperationException($"无法解析文件下载 URL: {fileKey}");
+                    
+                    if(!fileElement.TryGetProperty("downloads"u8,out var downloads) ||
+                       !downloads.TryGetProperty("raw"u8,out var raw)||
+                       !raw.TryGetProperty("url"u8,out var urlElement))throw new InvalidOperationException($"无法解析文件下载 URL: {fileKey}");
+                    var url = urlElement.GetString();
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
     
                     var success = false;
@@ -215,7 +226,7 @@ public sealed class JavaInstaller {
                 void ReportProgressWithSpeed(double currentFileProgress = 0.0) {
                     int snap = Volatile.Read(ref completedFiles);
                     double overallProgress = 0.7 + (0.3 * Math.Min((snap + currentFileProgress) / totalFiles, 1.0));
-                    double speed = globalDownloadedBytes / Math.Max(1.0, globalStopwatch.Elapsed.TotalSeconds); // Bytes/s
+                    double speed = globalDownloadedBytes / Math.Max(1.0, Stopwatch.GetElapsedTime(globalStopwatch).Seconds); // Bytes/s
     
                     ReportProgress(
                         InstallStep.DownloadJava,
@@ -243,7 +254,7 @@ public sealed class JavaInstaller {
             TaskStatus.Running,
             totalFiles,
             totalFiles,
-            globalDownloadedBytes / Math.Max(1.0, globalStopwatch.Elapsed.TotalSeconds));
+            globalDownloadedBytes / Math.Max(1.0, Stopwatch.GetElapsedTime(globalStopwatch).Seconds));
     }
     private string GetPlatformKey() {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {

--- a/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
@@ -147,16 +147,16 @@ public sealed class CurseforgeModpackInstaller : InstallerBase {
         return downloadInfoGroup;
     }
 
-    private async IAsyncEnumerable<string> RedirectInvalidModsAsync(IEnumerable<CurseforgeModpackFileEntry> modpacks, [EnumeratorCancellation] CancellationToken cancellationToken) {
-        ReportProgress(InstallStep.RedirectInvalidMod, 0.5d, TaskStatus.Running, modpacks.Count(), 0);
+    private async IAsyncEnumerable<string> RedirectInvalidModsAsync(List<CurseforgeModpackFileEntry> modpacks, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        ReportProgress(InstallStep.RedirectInvalidMod, 0.5d, TaskStatus.Running, modpacks.Count, 0);
 
         int count = 0;
-        int totalCount = modpacks.Count();
+        int totalCount = modpacks.Count;
         foreach (var modpackFile in modpacks) {
             var modFileName = (await CurseforgeProvider
                 .GetModFileEntryAsync(modpackFile.ProjectId, modpackFile.FileId, cancellationToken))
-                .GetString("fileName");
-
+                .GetProperty("fileName"u8).GetString();
+            
             lock (modpacks) {
                 var progress = (double)count / (double)totalCount;
 

--- a/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
@@ -119,7 +119,6 @@ public sealed class CurseforgeModpackInstaller : InstallerBase {
         List<Task> requestTasks = [];
         List<(string, CurseforgeModpackFileEntry)> downloadInfoGroup = [];
         SemaphoreSlim semaphoreSlim = new(256, 256);
-
         ReportProgress(InstallStep.ParseDownloadUrls, 0.1d, TaskStatus.Running, totalCount, count);
 
         foreach (var modpackFile in Entry.ModFiles) {

--- a/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
@@ -7,6 +7,7 @@ using MinecraftLaunch.Components.Provider;
 using MinecraftLaunch.Extensions;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace MinecraftLaunch.Components.Installer.Modpack;
 
@@ -30,10 +31,10 @@ public sealed class CurseforgeModpackInstaller : InstallerBase {
 
     public static CurseforgeModpackInstallEntry ParseModpackInstallEntry(string modpackPath) {
         using var zipArchive = ZipFile.OpenRead(modpackPath);
-        var json = zipArchive?.GetEntry("manifest.json")?.ReadAsString()
+        using var json = zipArchive?.GetEntry("manifest.json")?.Open()
             ?? throw new ArgumentException("Not found manifest.json");
 
-        var entry = json.Deserialize(CurseforgeModpackInstallEntryContext.Default.CurseforgeModpackInstallEntry)
+        var entry = JsonSerializer.Deserialize(json,CurseforgeModpackInstallEntryContext.Default.CurseforgeModpackInstallEntry)
             ?? throw new InvalidOperationException("Failed to parse manifest.json");
 
         return entry;

--- a/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
@@ -1,4 +1,5 @@
-﻿using MinecraftLaunch.Base.Enums;
+﻿using System.Diagnostics;
+using MinecraftLaunch.Base.Enums;
 using MinecraftLaunch.Base.Interfaces;
 using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Models.Network;
@@ -41,10 +42,11 @@ public sealed class CurseforgeModpackInstaller : InstallerBase {
     }
 
     public static async IAsyncEnumerable<IInstallEntry> ParseModLoaderEntryByManifestAsync(CurseforgeModpackInstallEntry entry, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        foreach (var loader in entry.Minecraft.ModLoaders) {
+        Debug.Assert(entry.Minecraft.ModLoaders.ValueKind is JsonValueKind.Array);
+        foreach (var loader in entry.Minecraft.ModLoaders.EnumerateArray()) {
             cancellationToken.ThrowIfCancellationRequested();
 
-            (bool isPrimary, string id) = (loader.GetBool("primary"), loader.GetString("id"));
+            (bool isPrimary, string id) = (loader.GetProperty("primary"u8).GetBoolean(), loader.GetProperty("id"u8).GetString());
             var idDatas = id.Split('-');
 
             var loaderVersion = idDatas.Last();

--- a/MinecraftLaunch/Components/Installer/Modpack/McbbsModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/McbbsModpackInstaller.cs
@@ -5,6 +5,7 @@ using MinecraftLaunch.Base.Models.Network;
 using MinecraftLaunch.Extensions;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace MinecraftLaunch.Components.Installer.Modpack;
 
@@ -48,10 +49,10 @@ public sealed class McbbsModpackInstaller : InstallerBase {
 
     public static McbbsModpackInstallEntry ParseModpackInstallEntry(string modpackPath) {
         using var zipArchive = ZipFile.OpenRead(modpackPath);
-        var json = zipArchive?.GetEntry("mcbbs.packmeta")?.ReadAsString()
+        using var stream = zipArchive?.GetEntry("mcbbs.packmeta")?.Open()
             ?? throw new ArgumentException("Not found mcbbs.packmeta");
 
-        return json.Deserialize(McbbsModpackInstallEntryContext.Default.McbbsModpackInstallEntry)
+        return JsonSerializer.Deserialize(stream,McbbsModpackInstallEntryContext.Default.McbbsModpackInstallEntry)
             ?? throw new InvalidOperationException("Failed to parsemcbbs.packmeta");
     }
 

--- a/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
@@ -4,8 +4,8 @@ using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Models.Network;
 using MinecraftLaunch.Components.Downloader;
 using MinecraftLaunch.Extensions;
-using System.IO;
 using System.IO.Compression;
+using System.Text.Json;
 
 namespace MinecraftLaunch.Components.Installer.Modpack;
 
@@ -17,10 +17,10 @@ public sealed class ModrinthModpackInstaller : InstallerBase {
 
     public static ModrinthModpackInstallEntry ParseModpackInstallEntry(string modpackPath) {
         using var zipArchive = ZipFile.OpenRead(modpackPath);
-        var json = zipArchive?.GetEntry("modrinth.index.json")?.ReadAsString()
+        using var json = zipArchive?.GetEntry("modrinth.index.json")?.Open()
             ?? throw new ArgumentException("Not found modrinth.index.json");
 
-        return json.Deserialize(ModrinthModpackInstallEntryContext.Default.ModrinthModpackInstallEntry)
+        return JsonSerializer.Deserialize(json,ModrinthModpackInstallEntryContext.Default.ModrinthModpackInstallEntry)
             ?? throw new InvalidOperationException("Failed to parse modrinth.index.json");
     }
 

--- a/MinecraftLaunch/Components/Installer/OptifineInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/OptifineInstaller.cs
@@ -7,7 +7,8 @@ using MinecraftLaunch.Components.Parser;
 using MinecraftLaunch.Extensions;
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Runtime.CompilerServices;
+
+using System.Text.Json;
 
 namespace MinecraftLaunch.Components.Installer;
 
@@ -174,9 +175,9 @@ public sealed class OptifineInstaller : InstallerBase {
             MainClass = "net.minecraft.launchwrapper.Launch",
             MinecraftArguments = "--tweakClass optifine.OptiFineTweaker"
         };
-
-        await File.WriteAllTextAsync(jsonFile.FullName,
-            jsonEntry.Serialize(MinecraftJsonEntryContext.Default.OptifineMinecraftEntry), cancellationToken);
+        await using var output = File.OpenWrite(jsonFile.FullName);
+        await JsonSerializer.SerializeAsync(output, jsonEntry, MinecraftJsonEntryContext.Default.OptifineMinecraftEntry,
+            cancellationToken);
 
         if (minecraft.ClientJarPath is null || !File.Exists(minecraft.ClientJarPath))
             throw new FileNotFoundException("Unable to find the original client client.jar file");

--- a/MinecraftLaunch/Components/Installer/QuiltInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/QuiltInstaller.cs
@@ -78,9 +78,10 @@ public sealed class QuiltInstaller : InstallerBase {
         string requestUrl = $"https://meta.quiltmc.org/v3/versions/loader/{Entry.McVersion}/{Entry.BuildVersion}/profile/json";
         requestUrl = DownloadManager.BmclApi.TryFindUrl(requestUrl);
 
-        var json = await requestUrl.GetStringAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
+        await using var jsonStream = await requestUrl.GetStreamAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(jsonStream, cancellationToken: cancellationToken);
         string entryId = CustomId ??
-            json.AsNode().GetString("id") ??
+            doc.RootElement.GetPropertyNullable("id"u8)?.GetString() ??
             $"quilt-loader-{Entry.Loader.Version}_{entry.Id}";
 
         var jsonFile = new FileInfo(Path
@@ -89,7 +90,9 @@ public sealed class QuiltInstaller : InstallerBase {
         if (!jsonFile.Directory!.Exists)
             jsonFile.Directory.Create();
 
-        await File.WriteAllTextAsync(jsonFile.FullName, json, cancellationToken);
+        await using var output = File.OpenWrite(jsonFile.FullName);
+        await JsonSerializer.SerializeAsync(output, doc, JsonDocumentSerializeContext.Default.JsonDocument,
+            cancellationToken);
 
         ReportProgress(InstallStep.DownloadVersionJson, 0.45d, TaskStatus.Running, 1, 1);
         return jsonFile;

--- a/MinecraftLaunch/Components/Installer/VanillaInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/VanillaInstaller.cs
@@ -62,14 +62,15 @@ public sealed class VanillaInstaller : InstallerBase {
         ReportProgress(InstallStep.DownloadVersionJson, 0.15d, TaskStatus.Running, 1, 0);
 
         string requestUrl = DownloadManager.BmclApi.TryFindUrl(Entry.Url);
-        var json = await requestUrl.GetStringAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
+        await using var jsonStream = await requestUrl.GetStreamAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
 
         var jsonPath = new FileInfo(Path.Combine(MinecraftFolder, "versions", Entry.Id, $"{Entry.Id}.json"));
         if (!jsonPath.Directory.Exists) {
             jsonPath.Directory.Create();
         }
 
-        await File.WriteAllTextAsync(jsonPath.FullName, json, cancellationToken);
+        await using var output = File.OpenWrite(jsonPath.FullName);
+        await jsonStream.CopyToAsync(output, cancellationToken);
         ReportProgress(InstallStep.DownloadVersionJson, 0.3d, TaskStatus.Running, 1, 1);
 
         return jsonPath;
@@ -83,13 +84,14 @@ public sealed class VanillaInstaller : InstallerBase {
         var jsonFile = new FileInfo(entry.AssetIndexJsonPath);
 
         string requestUrl = DownloadManager.BmclApi.TryFindUrl(assetIndex.Url);
-        var json = await requestUrl.GetStringAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
+        var json = await requestUrl.GetStreamAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
 
         if (!jsonFile.Directory.Exists) {
             jsonFile.Directory.Create();
         }
 
-        await File.WriteAllTextAsync(jsonFile.FullName, json, cancellationToken);
+        await using var output = File.OpenWrite(jsonFile.FullName);
+        await json.CopyToAsync(output, cancellationToken);
         ReportProgress(InstallStep.DownloadAssetIndexFile, 0.5d, TaskStatus.Running, 1, 1);
 
         return jsonFile;

--- a/MinecraftLaunch/Components/Installer/VanillaInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/VanillaInstaller.cs
@@ -23,11 +23,10 @@ public sealed class VanillaInstaller : InstallerBase {
     public static async Task<IEnumerable<VersionManifestEntry>> EnumerableMinecraftAsync(CancellationToken cancellationToken = default) {
         var url = DownloadManager.BmclApi
             .TryFindUrl("https://launchermeta.mojang.com/mc/game/version_manifest.json");
+        await using var stream = await url.GetStreamAsync(HttpCompletionOption.ResponseContentRead, cancellationToken);
+        using var node = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
 
-        var node = (await url.GetStringAsync(HttpCompletionOption.ResponseContentRead, cancellationToken))
-            .AsNode();
-
-        var entries = node.GetEnumerable("versions").Deserialize(VersionManifestEntryContext.Default.IEnumerableVersionManifestEntry);
+        var entries = node.RootElement.GetProperty("versions").Deserialize(VersionManifestEntryContext.Default.IEnumerableVersionManifestEntry);
         return entries;
     }
 

--- a/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
+++ b/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
@@ -3,13 +3,8 @@ using MinecraftLaunch.Base.Enums;
 using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Utilities;
 using MinecraftLaunch.Extensions;
-using MinecraftLaunch.Utilities;
-using System.Collections.Immutable;
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace MinecraftLaunch.Components.Parser;
 
@@ -282,17 +277,16 @@ internal sealed class GameArgumentParser
             }
         }
 
-        if (gameJsonEntry.Arguments?.GetEnumerable("game") is null)
-        {
+        if (!gameJsonEntry.Arguments.TryGetProperty("game"u8,out var gameElement))
             yield break;
-        }
+        
 
-        var game = gameJsonEntry.Arguments.GetEnumerable("game")
-            .Where(x => x.GetValueKind() is JsonValueKind.String)
+        var game = gameElement.EnumerateArray()
+            .Where(x => x.ValueKind is JsonValueKind.String)
             .Select(x => x.GetString().ToPath())
             .GroupArguments();
 
-        foreach (var item in game.ToImmutableArray())
+        foreach (var item in game)
             yield return item;
     }
 }
@@ -304,9 +298,7 @@ internal sealed class JvmArgumentParser
 {
     public static IEnumerable<string> Parse(MinecraftJsonEntry gameJsonEntry)
     {
-        var jvm = new List<string>();
-
-        if (gameJsonEntry.Arguments.GetEnumerable("jvm") is null)
+        if (!gameJsonEntry.Arguments.TryGetProperty("jvm"u8,out var jvmElement))
         {
             yield return "-Djava.library.path=${natives_directory}";
             yield return "-Dminecraft.launcher.brand=${launcher_name}";
@@ -314,12 +306,12 @@ internal sealed class JvmArgumentParser
             yield return "-cp ${classpath}";
             yield break;
         }
-
-        foreach (var arg in gameJsonEntry.Arguments.GetEnumerable("jvm"))
+        var jvm = new List<string>();
+        foreach (var arg in jvmElement.EnumerateArray())
         {
-            if (arg.GetValueKind() is JsonValueKind.String)
+            if (arg.ValueKind is JsonValueKind.String)
             {
-                var argValue = arg.GetString().Trim();
+                var argValue = arg.GetString()!.Trim();
 
                 if (argValue.Contains(' '))
                     jvm.AddRange(argValue.Split(' '));

--- a/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
+++ b/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
@@ -1,4 +1,5 @@
-﻿using MinecraftLaunch.Base.Enums;
+﻿using System.Buffers;
+using MinecraftLaunch.Base.Enums;
 using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Utilities;
 using MinecraftLaunch.Extensions;
@@ -6,37 +7,45 @@ using MinecraftLaunch.Utilities;
 using System.Collections.Immutable;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace MinecraftLaunch.Components.Parser;
 
-public sealed class ArgumentsParser {
+public sealed class ArgumentsParser
+{
     private IReadOnlyList<MinecraftLibrary> _natives;
     private IReadOnlyList<MinecraftLibrary> _libraries;
 
     public LaunchConfig LaunchConfig { get; init; }
     public MinecraftEntry MinecraftEntry { get; init; }
 
-    public ArgumentsParser(MinecraftEntry minecraftEntry, LaunchConfig launchConfig) {
+    public ArgumentsParser(MinecraftEntry minecraftEntry, LaunchConfig launchConfig)
+    {
         LaunchConfig = launchConfig;
         MinecraftEntry = minecraftEntry;
 
         LoadLibraries();
     }
 
-    [MemberNotNullWhen(true, nameof(LaunchConfig), nameof(LaunchConfig.Account), nameof(LaunchConfig.JavaPath), nameof(LaunchConfig.MaxMemorySize), nameof(LaunchConfig.MinMemorySize))]
+    [MemberNotNullWhen(true, nameof(LaunchConfig), nameof(LaunchConfig.Account), nameof(LaunchConfig.JavaPath),
+        nameof(LaunchConfig.MaxMemorySize), nameof(LaunchConfig.MinMemorySize))]
     private bool CanParse() =>
-        LaunchConfig != null && LaunchConfig.Account != null && LaunchConfig.JavaPath != null && LaunchConfig.MaxMemorySize > 0 && LaunchConfig.MinMemorySize > 0;
+        LaunchConfig is { Account: not null, JavaPath: not null } && LaunchConfig.MaxMemorySize > 0 &&
+        LaunchConfig.MinMemorySize > 0;
 
     internal IReadOnlyList<MinecraftLibrary> GetNatives() => _natives;
 
-    private void LoadLibraries() {
+    private void LoadLibraries()
+    {
         var natives = new List<MinecraftLibrary>();
         var libraries = new List<MinecraftLibrary>();
 
-        if (MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } modifiedMinecraftInstance) {
-            (var inheritedLibs, var inheritedNatives) = modifiedMinecraftInstance.InheritedMinecraft.GetRequiredLibraries();
+        if (MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } modifiedMinecraftInstance)
+        {
+            (var inheritedLibs, var inheritedNatives) =
+                modifiedMinecraftInstance.InheritedMinecraft.GetRequiredLibraries();
 
             libraries.AddRange(inheritedLibs);
             natives.AddRange(inheritedNatives);
@@ -45,23 +54,29 @@ public sealed class ArgumentsParser {
         (var libs, var nats) = MinecraftEntry.GetRequiredLibraries();
         natives.AddRange(nats);
 
-        foreach (var lib in libs) {
+        foreach (var lib in libs)
+        {
             MinecraftLibrary existsEqualLib = null;
             MinecraftLibrary sameNameLib = null;
 
-            foreach (var containedLib in libraries) {
-                if (lib.Equals(containedLib)) {
+            foreach (var containedLib in libraries)
+            {
+                if (lib.Equals(containedLib))
+                {
                     existsEqualLib = containedLib;
                     break;
-                } else if (lib.Name == containedLib.Name
-                      && lib.Classifier == containedLib.Classifier
-                      && lib.Domain == lib.Domain) {
+                }
+                else if (lib.Name == containedLib.Name
+                         && lib.Classifier == containedLib.Classifier
+                         && lib.Domain == lib.Domain)
+                {
                     sameNameLib = containedLib;
                     break;
                 }
             }
 
-            if (existsEqualLib == null) {
+            if (existsEqualLib == null)
+            {
                 libraries.Add(lib);
 
                 if (sameNameLib != null)
@@ -72,8 +87,9 @@ public sealed class ArgumentsParser {
         _libraries = libraries;
         _natives = natives;
     }
-
-    public IEnumerable<string> Parse() {
+    
+    public IEnumerable<string> Parse()
+    {
         if (!CanParse())
             throw new InvalidOperationException("Missing required parameters");
 
@@ -81,19 +97,18 @@ public sealed class ArgumentsParser {
             throw new InvalidOperationException("Invalid GameInfo");
 
         // Build arguments
-        var versionJsonNode = JsonNode.Parse(File.ReadAllText(MinecraftEntry.ClientJsonPath))
-            ?? throw new JsonException("Failed to parse version.json");
+        using var versionFile = File.OpenRead(MinecraftEntry.ClientJsonPath);
 
-        var entity = versionJsonNode.Deserialize(new MinecraftJsonEntryContext(JsonSerializerUtil.GetDefaultOptions()).MinecraftJsonEntry)
-            ?? throw new JsonException("Failed to parse version.json");
-
+        var entity = JsonSerializer.Deserialize(versionFile, MinecraftJsonEntryContext.Default.MinecraftJsonEntry)
+                     ?? throw new JsonException("Failed to parse version.json");
         var vmParameters = JvmArgumentParser.Parse(entity);
         var gameParameters = GameArgumentParser.Parse(entity);
-
-        if (MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } inst) {
-            var inheritedVersionEntry = JsonNode.Parse(File.ReadAllText(inst.InheritedMinecraft.ClientJsonPath))
-                .Deserialize(MinecraftJsonEntryContext.Default.MinecraftJsonEntry)
-                ?? throw new JsonException("Failed to parse version.json");
+        if (MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } inst)
+        {
+            using var inheritedVersionStream = File.OpenRead(inst.InheritedMinecraft.ClientJsonPath);
+            var inheritedVersionEntry = JsonSerializer.Deserialize(inheritedVersionStream,
+                                            MinecraftJsonEntryContext.Default.MinecraftJsonEntry)
+                                        ?? throw new JsonException("Failed to parse version.json");
 
             vmParameters = JvmArgumentParser
                 .Parse(inheritedVersionEntry)
@@ -104,38 +119,86 @@ public sealed class ArgumentsParser {
                 .Union(gameParameters);
         }
 
-        var classPath = string.Join(Path.PathSeparator, _libraries.Select(lib => lib.FullPath));
-        if (!string.IsNullOrEmpty(MinecraftEntry.ClientJarPath))
-            classPath += Path.PathSeparator + MinecraftEntry.ClientJarPath;
+        // 要求: libs[x].FullName is not null
+        [return: NotNull]
+        static string ProcessClassesPath([NotNull] IReadOnlyList<MinecraftLibrary> libs, string clientJPath)
+        {
+            var hasClientJarPath = !string.IsNullOrEmpty(clientJPath);
+            var libsPaths = ArrayPool<string>.Shared.Rent(libs.Count);
+            var totalSize = libs.Count - 1; // 为Path.PathSeparator预留长度
+            // 处理clientJPath
+            if (hasClientJarPath)
+            {
+                totalSize += clientJPath.Length;
+                totalSize += 1; // Path.PathSeparator
+            }
+
+            // 处理libs
+            for (var i = 0; i < libs.Count; i++)
+            {
+                libsPaths[i] = libs[i].FullPath;
+                totalSize += libsPaths[i].Length;
+            }
+            // #拷贝部分
+            // 声请缓冲区
+            var buffer = ArrayPool<char>.Shared.Rent(totalSize);
+            var offset = 0;
+            for (var i = 0; i < libs.Count; i++)
+            {
+                libsPaths[i].CopyTo(buffer.AsSpan(offset..));
+                offset += libsPaths[i].Length;
+                buffer[offset] = Path.PathSeparator;
+                offset += 1;
+            }
+
+            if (hasClientJarPath)
+            {
+                clientJPath.CopyTo(buffer.AsSpan(offset..));
+                offset += clientJPath.Length;
+            }
+            else
+            {
+                offset -= 1; // 去除最后一个 Path.PathSeparator
+            }
+            // 拷贝字符串
+            var result = new string(buffer.AsSpan(..offset));
+            // 释放资源
+            ArrayPool<char>.Shared.Return(buffer);
+            ArrayPool<string>.Shared.Return(libsPaths);
+            return result;
+        }
+
+        var classPath = ProcessClassesPath(_libraries, MinecraftEntry.ClientJarPath);
 
         var vmParametersReplace = new Dictionary<string, string>()
         {
-                { "${launcher_name}", "MinecraftLaunch" },
-                { "${launcher_version}", "4" },
-                { "${classpath_separator}", Path.PathSeparator.ToString() },
-                { "${library_directory}", MinecraftEntry.ToLibrariesPath().ToPath() },
-                { "${classpath}", classPath.ToPath() },
-                {
-                    "${version_name}", MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } instance
-                        ? instance.InheritedMinecraft.Id.ToPath()
-                        : MinecraftEntry.Id.ToPath()
-                },
-                {
-                    "${natives_directory}", string.IsNullOrEmpty(LaunchConfig.NativesFolder)
+            { "${launcher_name}", "MinecraftLaunch" },
+            { "${launcher_version}", "4" },
+            { "${classpath_separator}", Path.PathSeparator.ToString() },
+            { "${library_directory}", MinecraftEntry.ToLibrariesPath().ToPath() },
+            { "${classpath}", classPath.ToPath() },
+            {
+                "${version_name}", MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } instance
+                    ? instance.InheritedMinecraft.Id.ToPath()
+                    : MinecraftEntry.Id.ToPath()
+            },
+            {
+                "${natives_directory}", string.IsNullOrEmpty(LaunchConfig.NativesFolder)
                     ? MinecraftEntry.ToNativesPath().ToPath()
                     : LaunchConfig.NativesFolder.ToPath()
-                },
-            };
+            },
+        };
 
-        string assetIndexPath = MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } instance2 ?
-            instance2.InheritedMinecraft.AssetIndexJsonPath :
-            MinecraftEntry.AssetIndexJsonPath;
+        string assetIndexPath = MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } instance2
+            ? instance2.InheritedMinecraft.AssetIndexJsonPath
+            : MinecraftEntry.AssetIndexJsonPath;
 
         string assetIndexFilename = Path.GetFileNameWithoutExtension(assetIndexPath)
-            ?? throw new InvalidOperationException("Invalid asset index path");
+                                    ?? throw new InvalidOperationException("Invalid asset index path");
 
         string versionType = string.IsNullOrEmpty(LaunchConfig.LauncherName)
-            ? MinecraftEntry.Version.Type switch {
+            ? MinecraftEntry.Version.Type switch
+            {
                 MinecraftVersionType.Release => "release",
                 MinecraftVersionType.Snapshot => "snapshot",
                 MinecraftVersionType.OldBeta => "old_beta",
@@ -144,23 +207,24 @@ public sealed class ArgumentsParser {
             }
             : LaunchConfig.LauncherName;
 
-        var gameParametersReplace = new Dictionary<string, string>() {
-                { "${auth_player_name}" , LaunchConfig.Account.Name },
-                { "${auth_access_token}" , LaunchConfig.Account.AccessToken },
-                { "${auth_session}" , LaunchConfig.Account.AccessToken },
-                { "${auth_uuid}" ,LaunchConfig.Account.Uuid.ToString("N") },
-                { "${user_type}" , LaunchConfig.Account.Type.Equals(AccountType.Microsoft) ? "MSA" : "Mojang" },
-                { "${user_properties}" , "{}" },
-                { "${version_name}" , MinecraftEntry.Id.ToPath() },
-                { "${version_type}" , versionType },
-                { "${game_assets}" , Path.Combine(MinecraftEntry.MinecraftFolderPath, "assets").ToPath() },
-                { "${assets_root}" , Path.Combine(MinecraftEntry.MinecraftFolderPath, "assets").ToPath() },
-                { "${game_directory}" , MinecraftEntry.ToWorkingPath(LaunchConfig.IsEnableIndependency).ToPath() },
-                { "${assets_index_name}" , assetIndexFilename },
+        var gameParametersReplace = new Dictionary<string, string>()
+        {
+            { "${auth_player_name}", LaunchConfig.Account.Name },
+            { "${auth_access_token}", LaunchConfig.Account.AccessToken },
+            { "${auth_session}", LaunchConfig.Account.AccessToken },
+            { "${auth_uuid}", LaunchConfig.Account.Uuid.ToString("N") },
+            { "${user_type}", LaunchConfig.Account.Type.Equals(AccountType.Microsoft) ? "MSA" : "Mojang" },
+            { "${user_properties}", "{}" },
+            { "${version_name}", MinecraftEntry.Id.ToPath() },
+            { "${version_type}", versionType },
+            { "${game_assets}", Path.Combine(MinecraftEntry.MinecraftFolderPath, "assets").ToPath() },
+            { "${assets_root}", Path.Combine(MinecraftEntry.MinecraftFolderPath, "assets").ToPath() },
+            { "${game_directory}", MinecraftEntry.ToWorkingPath(LaunchConfig.IsEnableIndependency).ToPath() },
+            { "${assets_index_name}", assetIndexFilename },
         };
 
         var parentFolderPath = Directory.GetParent(MinecraftEntry.MinecraftFolderPath)?.FullName
-            ?? throw new InvalidOperationException("Invalid Minecraft folder path");
+                               ?? throw new InvalidOperationException("Invalid Minecraft folder path");
 
         yield return $"-Xms{LaunchConfig.MinMemorySize}M";
         yield return $"-Xmx{LaunchConfig.MaxMemorySize}M";
@@ -175,7 +239,8 @@ public sealed class ArgumentsParser {
 
         foreach (var arg in gameParameters) yield return arg.ReplaceFromDictionary(gameParametersReplace);
 
-        if (LaunchConfig.Width != 0 && LaunchConfig.Height != 0) {
+        if (LaunchConfig.Width != 0 && LaunchConfig.Height != 0)
+        {
             yield return $"--width {LaunchConfig.Width}";
             yield return $"--height {LaunchConfig.Height}";
         }
@@ -184,8 +249,10 @@ public sealed class ArgumentsParser {
         if (!string.IsNullOrWhiteSpace(LaunchConfig.SaveName) && isHighVersion)
             yield return $"--quickPlaySingleplayer {LaunchConfig.SaveName.ToPath()}";
 
-        if (LaunchConfig.ServerInfo is not null) {
-            if (isHighVersion) {
+        if (LaunchConfig.ServerInfo is not null)
+        {
+            if (isHighVersion)
+            {
                 yield return $"--quickPlayMultiplayer {LaunchConfig.ServerInfo.Address.ToPath()}";
                 yield break;
             }
@@ -199,19 +266,24 @@ public sealed class ArgumentsParser {
 /// <summary>
 /// 游戏参数解析器
 /// </summary>
-internal sealed class GameArgumentParser {
+internal sealed class GameArgumentParser
+{
     /// <summary>
     /// 解析参数
     /// </summary>
     /// <returns></returns>
-    public static IEnumerable<string> Parse(MinecraftJsonEntry gameJsonEntry) {
-        if (!string.IsNullOrEmpty(gameJsonEntry.MinecraftArguments)) {
-            foreach (var arg in gameJsonEntry.MinecraftArguments.Split(' ').GroupArguments()) {
+    public static IEnumerable<string> Parse(MinecraftJsonEntry gameJsonEntry)
+    {
+        if (!string.IsNullOrEmpty(gameJsonEntry.MinecraftArguments))
+        {
+            foreach (var arg in gameJsonEntry.MinecraftArguments.Split(' ').GroupArguments())
+            {
                 yield return arg;
             }
         }
 
-        if (gameJsonEntry.Arguments?.GetEnumerable("game") is null) {
+        if (gameJsonEntry.Arguments?.GetEnumerable("game") is null)
+        {
             yield break;
         }
 
@@ -228,11 +300,14 @@ internal sealed class GameArgumentParser {
 /// <summary>
 /// Jvm 虚拟机参数解析器
 /// </summary>
-internal sealed class JvmArgumentParser {
-    public static IEnumerable<string> Parse(MinecraftJsonEntry gameJsonEntry) {
+internal sealed class JvmArgumentParser
+{
+    public static IEnumerable<string> Parse(MinecraftJsonEntry gameJsonEntry)
+    {
         var jvm = new List<string>();
 
-        if (gameJsonEntry.Arguments.GetEnumerable("jvm") is null) {
+        if (gameJsonEntry.Arguments.GetEnumerable("jvm") is null)
+        {
             yield return "-Djava.library.path=${natives_directory}";
             yield return "-Dminecraft.launcher.brand=${launcher_name}";
             yield return "-Dminecraft.launcher.version=${launcher_version}";
@@ -240,8 +315,10 @@ internal sealed class JvmArgumentParser {
             yield break;
         }
 
-        foreach (var arg in gameJsonEntry.Arguments.GetEnumerable("jvm")) {
-            if (arg.GetValueKind() is JsonValueKind.String) {
+        foreach (var arg in gameJsonEntry.Arguments.GetEnumerable("jvm"))
+        {
+            if (arg.GetValueKind() is JsonValueKind.String)
+            {
                 var argValue = arg.GetString().Trim();
 
                 if (argValue.Contains(' '))
@@ -263,14 +340,18 @@ internal sealed class JvmArgumentParser {
     /// 获取虚拟机环境参数
     /// </summary>
     /// <returns></returns>
-    public static IEnumerable<string> GetEnvironmentJvmArguments() {
-        switch (EnvironmentUtil.GetPlatformName()) {
+    public static IEnumerable<string> GetEnvironmentJvmArguments()
+    {
+        switch (EnvironmentUtil.GetPlatformName())
+        {
             case "windows":
                 yield return "-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump";
-                if (Environment.OSVersion.Version.Major == 10) {
+                if (Environment.OSVersion.Version.Major == 10)
+                {
                     yield return "-Dos.name=\"Windows 10\"";
                     yield return "-Dos.version=10.0";
                 }
+
                 break;
             case "osx":
                 yield return "-XstartOnFirstThread";

--- a/MinecraftLaunch/Components/Parser/LauncherProfileParser.cs
+++ b/MinecraftLaunch/Components/Parser/LauncherProfileParser.cs
@@ -34,9 +34,8 @@ public sealed class DefaultLauncherProfileParser : IDataProcessor {
         _filePath = Path.Combine(mcList[0].MinecraftFolderPath, "launcher_profiles.json");
 
         if (File.Exists(_filePath)) {
-            var launcherProfileJson = File.ReadAllText(_filePath, Encoding.UTF8);
-            _launcherProfile = launcherProfileJson.Deserialize(new LauncherProfileEntryContext(JsonSerializerUtil
-                .GetDefaultOptions()).LauncherProfileEntry) ?? new LauncherProfileEntry();
+            using var stream = File.OpenRead(_filePath);
+            _launcherProfile = JsonSerializer.Deserialize(stream,LauncherProfileEntryContext.Default.LauncherProfileEntry) ?? new LauncherProfileEntry();
         } else {
             _launcherProfile = new LauncherProfileEntry {
                 Profiles = [],
@@ -62,12 +61,9 @@ public sealed class DefaultLauncherProfileParser : IDataProcessor {
         Datas = _launcherProfile.Profiles.ToDictionary(x => x.Key, x1 => x1.Value as object);
     }
 
-    public Task SaveAsync(CancellationToken cancellationToken = default) {
+    public async Task SaveAsync(CancellationToken cancellationToken = default) {
         _launcherProfile.Profiles = Datas.ToDictionary(x => x.Key, x1 => x1.Value as GameProfileEntry);
-        var json = _launcherProfile.Serialize(
-            new LauncherProfileEntryContext(JsonSerializerUtil.GetDefaultOptions()).LauncherProfileEntry
-        );
-
-        return File.WriteAllTextAsync(_filePath, json, cancellationToken);
+        await using var output = File.OpenWrite(_filePath);
+        await JsonSerializer.SerializeAsync(output, _launcherProfile,LauncherProfileEntryContext.Default.LauncherProfileEntry, cancellationToken);
     }
 }

--- a/MinecraftLaunch/Components/Parser/MinecraftParser.cs
+++ b/MinecraftLaunch/Components/Parser/MinecraftParser.cs
@@ -88,11 +88,9 @@ public sealed class MinecraftParser {
         string clientJsonPath = clientJsonFile.FullName;
 
         // Parse client.json
-        string clientJson = File.ReadAllText(clientJsonPath);
-        var clientJsonNode = JsonNode.Parse(clientJson)
-            ?? throw new JsonException($"Failed to parse {clientJsonPath}");
-
-        var clientJsonObject = clientJson.Deserialize(new MinecraftJsonEntryContext(JsonSerializerUtil.GetDefaultOptions()).MinecraftJsonEntry)
+        using var stream = clientJsonFile.OpenRead();
+        using var doc = JsonDocument.Parse(stream);
+        var clientJsonObject = doc.Deserialize(MinecraftJsonEntryContext.Default.MinecraftJsonEntry)
             ?? throw new JsonException($"Failed to deserialize {clientJsonPath} into {typeof(MinecraftJsonEntry)}");
 
         // <version> folder name
@@ -106,8 +104,8 @@ public sealed class MinecraftParser {
 
         // Create MinecraftInstance
         return IsVanilla(clientJsonObject)
-            ? ParseVanilla(partialData, clientJsonObject, clientJsonNode)
-            : ParseModified(partialData, clientJsonObject, clientJsonNode, parsedInstances, out foundInheritedInstanceInParsed);
+            ? ParseVanilla(partialData, clientJsonObject, doc.RootElement)
+            : ParseModified(partialData, clientJsonObject, doc.RootElement, parsedInstances, out foundInheritedInstanceInParsed);
     }
 
     private static bool IsVanilla(MinecraftJsonEntry clientJsonObject) {
@@ -124,38 +122,41 @@ public sealed class MinecraftParser {
             clientJsonObject.MinecraftArguments?.Contains("--tweakClass") == true
             && clientJsonObject.MinecraftArguments?.Contains("net.minecraft.launchwrapper.AlphaVanillaTweaker") == false
             // Since 1.13
-            || clientJsonObject.Arguments?.GetEnumerable("game")?
-                .Where(e => e.GetValueKind() is JsonValueKind.String && e.GetString().Equals("--tweakClass"))
-                .Any() == true;
-
+            || CheckIfOver113(clientJsonObject.Arguments);
+        
         if (!string.IsNullOrEmpty(clientJsonObject.InheritsFrom)
             || !hasVanillaMainClass
             || hasVanillaMainClass && hasTweakClass)
             return false;
 
         return true;
-    }
 
-    private static string ReadVersionIdFromNonInheritingClientJson(MinecraftJsonEntry gameJsonEntry, JsonNode clientJsonNode) {
-        string versionId = gameJsonEntry.Id;
-
-        try {
-            if (clientJsonNode["patches"] is JsonNode hmclPatchesNode) {
-                versionId = hmclPatchesNode[0]?["version"]?.GetValue<string>();
-            } else if (clientJsonNode["clientVersion"] is JsonNode pclClientVersionNode) {
-                versionId = pclClientVersionNode.GetValue<string>();
+        static bool CheckIfOver113(JsonElement argumentElement)
+        {
+            if (!argumentElement.TryGetProperty("game"u8, out var gameElement)) return false;
+            foreach (var item in gameElement.EnumerateArray())
+            {
+                if (item.ValueKind is JsonValueKind.String &&
+                    string.Equals(item.GetString()!, "--tweakClass", StringComparison.Ordinal)) return true;
             }
-
-            if (versionId is null)
-                throw new FormatException();
-        } catch (Exception e) when (e is InvalidOperationException || e is FormatException) {
-            throw new FormatException("Failed to parse version id");
+            return false;
         }
-
-        return versionId;
     }
 
-    private static VanillaMinecraftEntry ParseVanilla(PartialData partialData, MinecraftJsonEntry gameJsonEntry, JsonNode clientJsonNode) {
+    private static string ReadVersionIdFromNonInheritingClientJson(MinecraftJsonEntry gameJsonEntry,
+        JsonElement clientJsonNode)
+    {
+        var versionId = gameJsonEntry.Id;
+        
+        if (clientJsonNode.TryGetProperty("patches"u8, out var hmclPatchesNode))
+            versionId = hmclPatchesNode[0].GetProperty("version"u8).GetString();
+        else if (clientJsonNode.TryGetProperty("clientVersion"u8, out var pclClientVersionNode)) 
+            versionId = pclClientVersionNode.GetString();
+
+        return versionId ?? throw new FormatException("Failed to parse version id");
+    }
+
+    private static VanillaMinecraftEntry ParseVanilla(PartialData partialData, MinecraftJsonEntry gameJsonEntry, JsonElement clientJsonNode) {
         // Check if client.jar exists
         string clientJarPath = partialData.ClientJsonPath[..^"json".Length] + "jar";
 
@@ -179,7 +180,7 @@ public sealed class MinecraftParser {
         };
     }
 
-    private static ModifiedMinecraftEntry ParseModified(PartialData partialData, MinecraftJsonEntry minecraftJsonEntry, JsonNode clientJsonNode,
+    private static ModifiedMinecraftEntry ParseModified(PartialData partialData, MinecraftJsonEntry minecraftJsonEntry, JsonElement clientJsonNode,
         IEnumerable<MinecraftEntry> minecraftEntries,
         out bool foundInheritedInstanceInParsed) {
         foundInheritedInstanceInParsed = false;
@@ -191,9 +192,7 @@ public sealed class MinecraftParser {
             string inheritedInstanceId = minecraftJsonEntry.InheritsFrom
                 ?? throw new InvalidOperationException("InheritsFrom is not defined in client.json");
 
-            inheritedEntry = minecraftEntries?
-                .Where(i => i is VanillaMinecraftEntry v && v.Version.VersionId == inheritedInstanceId)
-                .FirstOrDefault() as VanillaMinecraftEntry;
+            inheritedEntry = minecraftEntries.FirstOrDefault(i => i is VanillaMinecraftEntry v && v.Version.VersionId == inheritedInstanceId) as  VanillaMinecraftEntry;
 
             if (inheritedEntry is not null) {
                 foundInheritedInstanceInParsed = true;
@@ -201,7 +200,7 @@ public sealed class MinecraftParser {
                 string inheritedInstancePath = Path.Combine(partialData.MinecraftFolderPath, "versions", inheritedInstanceId);
                 var inheritedInstanceDir = new DirectoryInfo(inheritedInstancePath);
 
-                inheritedEntry = Parse(inheritedInstanceDir, null, out var _) as VanillaMinecraftEntry
+                inheritedEntry = Parse(inheritedInstanceDir, null, out  _) as VanillaMinecraftEntry
                     ?? throw new InvalidOperationException($"Failed to parse inherited instance {inheritedInstanceId}");
             }
         }
@@ -231,23 +230,24 @@ public sealed class MinecraftParser {
 
         // Parse mod loaders
         List<ModLoaderInfo> modLoaders = [];
-        var libraries = minecraftJsonEntry.Libraries ?? [];
-        foreach (var lib in libraries) {
-            string libNameLowered = lib.GetString("name")?.ToLower();
-            if (libNameLowered is null)
+        var librariesElement = minecraftJsonEntry.Libraries;
+        foreach (var lib in librariesElement.EnumerateArray()) {
+            if(!lib.TryGetProperty("name"u8, out var libNameElement))continue;
+            var libName = libNameElement.GetString();
+            if (libName is null)
                 continue;
 
             foreach (var key in _modLoaderLibs.Keys) {
-                if (!libNameLowered.Contains(key))
+                if (!libName.Contains(key,StringComparison.OrdinalIgnoreCase))
                     continue;
-
+                
                 // Mod loader library detected
-                var id = libNameLowered.Split(':')[2];
+                var id = libName.Split(':')[2];
                 var loader = new ModLoaderInfo {
                     Type = _modLoaderLibs[key].Item1,
                     Version = _modLoaderLibs[key].Item2(id)
                 };
-
+                
                 if (!modLoaders.Contains(loader))
                     modLoaders.Add(loader);
 

--- a/MinecraftLaunch/Components/Parser/MinecraftParser.cs
+++ b/MinecraftLaunch/Components/Parser/MinecraftParser.cs
@@ -1,11 +1,9 @@
 using MinecraftLaunch.Base.Enums;
 using MinecraftLaunch.Base.Interfaces;
 using MinecraftLaunch.Base.Models.Game;
-using MinecraftLaunch.Extensions;
-using MinecraftLaunch.Utilities;
 using System.Collections.Frozen;
+using System.Diagnostics;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace MinecraftLaunch.Components.Parser;
 
@@ -146,10 +144,13 @@ public sealed class MinecraftParser {
     private static string ReadVersionIdFromNonInheritingClientJson(MinecraftJsonEntry gameJsonEntry,
         JsonElement clientJsonNode)
     {
+        Debug.Assert(clientJsonNode.ValueKind == JsonValueKind.Object);
         var versionId = gameJsonEntry.Id;
-        
         if (clientJsonNode.TryGetProperty("patches"u8, out var hmclPatchesNode))
+        {
+            if(hmclPatchesNode.GetArrayLength() < 0)throw new FormatException("Failed to parse version id");
             versionId = hmclPatchesNode[0].GetProperty("version"u8).GetString();
+        }
         else if (clientJsonNode.TryGetProperty("clientVersion"u8, out var pclClientVersionNode)) 
             versionId = pclClientVersionNode.GetString();
 

--- a/MinecraftLaunch/Components/Provider/CurseforgeProvider.cs
+++ b/MinecraftLaunch/Components/Provider/CurseforgeProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Flurl;
 using Flurl.Http;
 using MinecraftLaunch.Base.Enums;
@@ -5,7 +6,7 @@ using MinecraftLaunch.Base.Models.Network;
 using MinecraftLaunch.Extensions;
 using MinecraftLaunch.Utilities;
 using System.Net.Http.Json;
-using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Web;
@@ -23,31 +24,53 @@ public sealed class CurseforgeProvider {
             CurseforgeRequestPayloadContext.Default.CurseforgeFingerprintsRequestPayload),
                 cancellationToken: cancellationToken);
 
-        var json = await responseMessage.GetStringAsync();
-        var jsonNode = json.AsNode()
-            .Select("data");
+        await using var stream = await responseMessage.GetStreamAsync();
+        using var doc  = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var exactMatches = doc.RootElement.GetPropertyNullable("data"u8)?.GetPropertyNullable("exactMatches");
+        
+        // 此处对API行为有变更,document会释放所以需要立即终结迭代器,不能延迟执行
+        return exactMatches?
+            .EnumerateObject()
+            .ToDictionary(
+                // key为null那本来也要抛出了,所以就不做检查
+                keySelector: x => ParseFile(x.Value.GetProperty("file"u8)),
+                // 这里需要立即终结迭代器,不能延迟
+                elementSelector: IEnumerable<CurseforgeResourceFile> /*写明返回类型*/
+                    (y) => ProvideResources(y.Value)
+            );
 
-        var exactMatches = jsonNode.GetEnumerable("exactMatches");
-        if (exactMatches is null)
-            return null;
+        static CurseforgeResourceFile[] ProvideResources(JsonElement propertyElement)
+        {
+            var latestFilesElement = propertyElement.GetProperty("latestFiles"u8);
+            var length = latestFilesElement.GetArrayLength();
+            var result = new CurseforgeResourceFile[length];
+            var offset = 0;
+            foreach (var item in latestFilesElement.EnumerateArray())
+            {
+                result[offset] = ParseFile(item);
+                offset++;
+            }
 
-        return exactMatches.ToDictionary(x => ParseFile(x.Select("file")),
-            x1 => x1.GetEnumerable("latestFiles").Select(ParseFile));
+            return result;
+        }
     }
 
-    public async Task<IEnumerable<CurseforgeResource>> GetResourcesByModIdsAsync(IEnumerable<long> modIds, CancellationToken cancellationToken = default) {
+    public Task<IEnumerable<CurseforgeResource>> GetResourcesByModIdsAsync(IEnumerable<long> modIds,
+        CancellationToken cancellationToken = default) =>
+        /*转移到long[]重载*/GetResourcesByModIdsAsync([..modIds], cancellationToken);
+    public async Task<IEnumerable<CurseforgeResource>> GetResourcesByModIdsAsync(long[] modIds, CancellationToken cancellationToken = default) {
         var request = CreateRequest("mods");
-        var payload = new CurseforgeResourcesRequestPayload([.. modIds]);
+        var payload = new CurseforgeResourcesRequestPayload(modIds);
 
         using var responseMessage = await request.PostAsync(JsonContent.Create(payload,
             CurseforgeRequestPayloadContext.Default.CurseforgeResourcesRequestPayload),
                 cancellationToken: cancellationToken);
 
-        var json = await responseMessage.GetStringAsync();
-        var jsonNode = json.AsNode()
-            .Select("data");
-
-        return jsonNode.GetEnumerable().Select(Parse);
+        await using var stream = await responseMessage.GetStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var dataElement = doc.RootElement.GetProperty("data"u8);
+        // 终结迭代器操作,Document不适用LINQ
+        return dataElement.EnumerateArrayThenSelectToArray(Parse);
     }
 
     public async Task<IEnumerable<CurseforgeResource>> GetFeaturedResourcesAsync(CancellationToken cancellationToken = default) {
@@ -57,21 +80,28 @@ public sealed class CurseforgeProvider {
         using var responseMessage = await request.PostAsync(JsonContent.Create(payload,
             CurseforgeRequestPayloadContext.Default.CurseforgeFeaturedRequestPayload),
                 cancellationToken: cancellationToken);
+        await using var stream = await responseMessage.GetStreamAsync();
+        using var doc  = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var dataElement = doc.RootElement.GetProperty("data"u8);
 
-        var jsonNode = (await responseMessage.GetStringAsync())
-            .AsNode()
-            .Select("data");
+        var popular = dataElement.GetPropertyNullable("popular");
+        var featured = dataElement.GetPropertyNullable("featured");
 
-        var popular = jsonNode.GetEnumerable("popular");
-        var featured = jsonNode.GetEnumerable("featured");
+        
+        if (popular is null || featured is null) return [];
+        // 使用HashSet去重
+        var length = popular.Value.GetArrayLength() + featured.Value.GetArrayLength();
+        var source = new HashSet<CurseforgeResource>(length);
+        foreach (var item in popular.Value.EnumerateArray())
+        {
+            source.Add(Parse(item));
+        }
+        foreach (var item in featured.Value.EnumerateArray())
+        {
+            source.Add(Parse(item));
+        }
 
-        IEnumerable<JsonNode> resources;
-        if (popular is not null && featured is not null)
-            resources = popular.Union(featured);
-        else
-            return [];
-
-        return resources.Select(Parse);
+        return source;
     }
 
     public async Task<IEnumerable<CurseforgeResource>> SearchResourcesAsync(
@@ -96,13 +126,17 @@ public sealed class CurseforgeProvider {
         if (modLoaderType != ModLoaderType.Any && modLoaderType != ModLoaderType.Unknown)
             url.SetQueryParam("modLoaderType", (int)modLoaderType);
 
-        var json = await CreateRequest(url).GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = json.AsNode();
-
-        if (jsonNode == null)
+        try
+        {
+            await using var stream = await CreateRequest(url).GetStreamAsync(cancellationToken: cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            return doc.RootElement.GetProperty("data"u8).EnumerateArrayThenSelectToArray(Parse);
+        }
+        // 这个只是为了和原API保持一致加的
+        catch
+        {
             return [];
-
-        return jsonNode.GetEnumerable("data").Select(Parse);
+        }
     }
 
     public async Task<IEnumerable<CurseforgeResource>> SearchResourcesAsync(
@@ -125,13 +159,17 @@ public sealed class CurseforgeProvider {
         if (modLoaderType != ModLoaderType.Any && modLoaderType != ModLoaderType.Unknown)
             url.SetQueryParam("modLoaderType", (int)modLoaderType);
 
-        var json = await CreateRequest(url).GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = json.AsNode();
-
-        if (jsonNode == null)
+        try
+        {
+            await using var stream = await CreateRequest(url).GetStreamAsync(cancellationToken: cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            return doc.RootElement.GetProperty("data"u8).EnumerateArrayThenSelectToArray(Parse);
+        }
+        // 这个只是为了和原API保持一致加的
+        catch
+        {
             return [];
-
-        return jsonNode.GetEnumerable("data").Select(Parse);
+        }
     }
 
     #region Private and internals
@@ -193,46 +231,74 @@ public sealed class CurseforgeProvider {
         throw new InvalidOperationException();
     }
 
-    private static CurseforgeResource Parse(JsonNode node) {
+    private static CurseforgeResource Parse(JsonElement resElement)
+    {
         return new CurseforgeResource {
-            Id = node.GetInt32("id"),
-            ClassId = node.GetInt32("classId"),
-            DownloadCount = node.GetInt32("downloadCount"),
-            Name = node.GetString("name"),
-            Slug = node.GetString("slug"),
-            Summary = node.GetString("summary"),
-            DateModified = node.GetDateTime("dateModified"),
-            IconUrl = node.Select("logo").GetString("thumbnailUrl"),
-            WebsiteUrl = node.Select("links").GetString("websiteUrl"),
-            Authors = node.GetEnumerable<string>("authors", "name"),
-            Categories = node.GetEnumerable<string>("categories", "name"),
-            Screenshots = node.GetEnumerable<string>("screenshots", "url"),
-            LatestFiles = node.GetEnumerable("latestFiles").Select(ParseFile),
-            MinecraftVersions = node.GetEnumerable<string>("latestFilesIndexes", "gameVersion").Distinct()
+            Id = resElement.GetProperty("id"u8).GetInt32(),
+            ClassId = resElement.GetProperty("classId"u8).GetInt32(),
+            DownloadCount = resElement.GetProperty("downloadCount"u8).GetInt32(),
+            Name = resElement.GetProperty("name"u8).GetString(),
+            Slug = resElement.GetProperty("slug"u8).GetString(),
+            Summary = resElement.GetProperty("summary"u8).GetString(),
+            DateModified = resElement.GetProperty("dateModified"u8).GetDateTime(),
+            IconUrl = resElement.GetProperty("logo"u8).GetProperty("thumbnailUrl"u8).GetString(),
+            WebsiteUrl = resElement.GetProperty("links"u8).GetProperty("websiteUrl"u8).GetString(),
+            Authors = resElement.GetProperty("authors"u8).EnumerateArrayThenSelectNotNullStringPropertyWithNotNullAndNotEmptyValueThenToArray("name"u8),
+            Categories = resElement.GetProperty("categories"u8).EnumerateArrayThenSelectNotNullStringPropertyWithNotNullAndNotEmptyValueThenToArray("name"u8),
+            Screenshots = resElement.GetProperty("screenshots"u8).EnumerateArrayThenSelectNotNullStringPropertyWithNotNullAndNotEmptyValueThenToArray("url"u8),
+            LatestFiles = resElement.GetProperty("latestFiles"u8).EnumerateArrayThenSelectToArray(ParseFile),
+            MinecraftVersions = resElement.GetProperty("latestFilesIndexes"u8)
+                .EnumerateArrayThenSelectToArray(x => x.GetProperty("gameVersion"u8).GetString())
+                .Distinct()
         };
+        
+
+        
     }
 
-    private static CurseforgeResourceFile ParseFile(JsonNode node) {
-        return node is null ? null : new CurseforgeResourceFile {
-            Id = node.GetInt32("id"),
-            ModId = node.GetInt32("modId"),
-            GameId = node.GetInt32("gameId"),
-            FileName = node.GetString("fileName"),
-            Published = node.GetDateTime("fileDate"),
-            IsAvailable = node.GetBool("isAvailable"),
-            DisplayName = node.GetString("displayName"),
-            IsServerPack = node.GetBool("isServerPack"),
-            DownloadUrl = node.GetString("downloadUrl"),
-            DownloadCount = node.GetInt32("downloadCount"),
-            AlternateFileId = node.GetInt32("alternateFileId"),
-            FileFingerprint = node.GetUInt32("fileFingerprint"),
-            GameVersions = node.GetEnumerable<string>("gameVersions"),
-            IsApproved = node.GetInt32("fileStatus") is 4,
-            FileLength = node.GetInt64("fileLength").Value,
-            ReleaseType = (FileReleaseType)node.GetInt32("releaseType"),
-            Sha1 = node.GetEnumerable("hashes").FirstOrDefault(x => x.GetInt32("algo") == 1).GetString("value"),
-            Dependencies = node.GetEnumerable("dependencies").DistinctBy(x => x.GetInt32("modId")).ToDictionary(x => x.GetInt32("modId"), x => (DependencyType)x.GetInt32("relationType")),
+    private static CurseforgeResourceFile ParseFile(JsonElement node) {
+        return new CurseforgeResourceFile {
+            Id = node.GetProperty("id"u8).GetInt32(),
+            ModId = node.GetProperty("modId"u8).GetInt32(),
+            GameId = node.GetProperty("gameId"u8).GetInt32(),
+            FileName = node.GetProperty("fileName"u8).GetString(),
+            Published = node.GetProperty("fileDate"u8).GetDateTime(),
+            IsAvailable = node.GetProperty("isAvailable"u8).GetBoolean(),
+            DisplayName = node.GetProperty("displayName"u8).GetString(),
+            IsServerPack = node.GetProperty("isServerPack"u8).GetBoolean(),
+            DownloadUrl = node.GetProperty("downloadUrl"u8).GetString(),
+            DownloadCount = node.GetProperty("downloadCount"u8).GetInt32(),
+            AlternateFileId = node.GetProperty("alternateFileId"u8).GetInt32(),
+            FileFingerprint = node.GetProperty("fileFingerprint"u8).GetUInt32(),
+            GameVersions = node.GetProperty("gameVersions"u8).EnumerateArrayThenSelectToArray(static i=>i.GetString()),
+            IsApproved = node.GetProperty("fileStatus"u8).GetInt32() is 4,
+            FileLength = node.GetProperty("fileLength"u8).GetInt64(),
+            ReleaseType = (FileReleaseType)node.GetProperty("releaseType"u8).GetInt32(),
+            // 手写目的在于防止LINQ访问被释放的资源,必须全量加载
+            Sha1 = ProvideSha(node.GetProperty("hashes"u8)),
+            Dependencies = ProvideDependencies(node.GetProperty("dependencies"u8))
+                
         };
+
+        
+        static Dictionary<int, DependencyType> ProvideDependencies(JsonElement dependenciesArrayElement)
+        {
+            return dependenciesArrayElement.EnumerateArray()
+                .DistinctBy(x => x.GetProperty("modId"u8).GetInt32())
+                .ToDictionary(
+                    x => x.GetProperty("modId"u8).GetInt32(),
+                    x => (DependencyType)x.GetProperty("relationType"u8).GetInt32()
+                );
+        }
+        static string ProvideSha(JsonElement hashesArrayNode)
+        {
+            foreach (var node in hashesArrayNode.EnumerateArray())
+            {
+                if (!node.TryGetProperty("algo"u8,out var algoElement))continue;
+                if (algoElement.GetInt32() is 1) return node.GetProperty("value"u8).GetString();
+            }
+            return string.Empty;
+        }
     }
 
     private static IFlurlRequest CreateRequest(Url url) {

--- a/MinecraftLaunch/Components/Provider/CurseforgeProvider.cs
+++ b/MinecraftLaunch/Components/Provider/CurseforgeProvider.cs
@@ -174,37 +174,41 @@ public sealed class CurseforgeProvider {
 
     #region Private and internals
 
-    internal static async Task<JsonNode> GetModFileEntryAsync(long modId, long fileId, CancellationToken cancellationToken = default) {
+    internal static async Task<JsonElement> GetModFileEntryAsync(long modId, long fileId,
+        CancellationToken cancellationToken = default)
+    {
         CheckApiKey();
 
-        string json = string.Empty;
-        try {
+        try
+        {
             using var responseMessage = await CreateRequest("mods", "files", $"{fileId}")
-                .GetAsync(cancellationToken: cancellationToken); ;
+                .GetAsync(cancellationToken: cancellationToken);
+            await using var json = await responseMessage.GetStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(json, cancellationToken: cancellationToken);
+            return doc.RootElement.GetProperty("data").Clone();
 
-            json = await responseMessage.GetStringAsync();
-        } catch (Exception) { }
-
-        return json?.AsNode()?.Select("data") ??
-            throw new InvalidModpackFileException();
+        }
+        catch (Exception e)
+        {
+            throw new InvalidModpackFileException("The modpack file could not be read.", e);
+        }
+               
     }
 
-    internal static async Task<string> GetModDownloadUrlAsync(long modId, long fileId, CancellationToken cancellationToken = default) {
+    internal static async Task<string> GetModDownloadUrlAsync(long modId, long fileId,
+        CancellationToken cancellationToken = default)
+    {
         CheckApiKey();
 
-        string json = string.Empty;
-        try {
-            using var responseMessage = await CreateRequest("mods", $"{modId}", "files", $"{fileId}", "download-url")
-                .GetAsync(cancellationToken: cancellationToken);
 
-            json = await responseMessage.GetStringAsync();
-        } catch (FlurlHttpException ex) {
-            if (ex.StatusCode is 403)
-                return string.Empty;
-        }
+        using var responseMessage = await CreateRequest("mods", $"{modId}", "files", $"{fileId}", "download-url")
+            .GetAsync(cancellationToken: cancellationToken);
+        await using var stream = await responseMessage.GetStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        // get data
+        if (!doc.RootElement.TryGetProperty("data", out var dataElement)) return string.Empty;
+        return dataElement.GetString() ?? throw new InvalidModpackFileException();
 
-        return json?.AsNode()?.GetString("data")
-            ?? throw new InvalidModpackFileException();
     }
 
     internal static async Task<string> TestDownloadUrlAsync(long fileId, string fileName, CancellationToken cancellationToken = default) {

--- a/MinecraftLaunch/Components/Provider/ModrinthProvider.cs
+++ b/MinecraftLaunch/Components/Provider/ModrinthProvider.cs
@@ -210,7 +210,7 @@ public sealed class ModrinthProvider {
         Debug.Assert(node.ValueKind == JsonValueKind.Object);
         var filesElement = node.GetProperty("files"u8);
         Debug.Assert(filesElement.ValueKind == JsonValueKind.Array);
-        JsonElement primaryFileNode = filesElement[0];
+        var primaryFileNode = filesElement[0];
         foreach (var item in filesElement.EnumerateArray())
         {
             if (!item.TryGetProperty("primary"u8, out var isPrimaryElement) || !isPrimaryElement.GetBoolean()) continue;

--- a/MinecraftLaunch/Components/Provider/ModrinthProvider.cs
+++ b/MinecraftLaunch/Components/Provider/ModrinthProvider.cs
@@ -1,13 +1,13 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Flurl;
 using Flurl.Http;
 using MinecraftLaunch.Base.Enums;
-using MinecraftLaunch.Base.Models.Authentication.Yggdrasil;
 using MinecraftLaunch.Base.Models.Network;
 using MinecraftLaunch.Extensions;
 using MinecraftLaunch.Utilities;
 using System.Net.Http.Json;
-using System.Text;
-using System.Text.Json.Nodes;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MinecraftLaunch.Components.Provider;
@@ -39,23 +39,24 @@ public sealed class ModrinthProvider {
             ModrinthProviderContext.Default.ModrinthFilesUpdateCheckRequestPayload),
                 cancellationToken: cancellationToken);
 
-        var jsonNode = (await responseMessage.GetStringAsync())
-            .AsNode();
-
-        return hashes.Select(x => ParseFile(jsonNode.Select(x)))
-            .Where(x => x is not null);
+        await using var stream = await responseMessage.GetStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var root = doc.RootElement;
+        var result = new ModrinthResourceFile[hashes.Length];
+        for (var i = 0; i < hashes.Length; i++)
+        {
+            result[i] = ParseFile(root.GetProperty(hashes[i]));
+        }
+        return result;
     }
 
     public async Task<IEnumerable<ModrinthResource>> GetFeaturedResourcesAsync(CancellationToken cancellationToken = default) {
         var request = HttpUtil.Request(ModrinthApi, "search");
 
-        var json = await request.GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = json.AsNode();
-
-        if (jsonNode is null)
-            return [];
-
-        return jsonNode.GetEnumerable("hits").Select(x => Parse(x));
+        await using var json = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(json, cancellationToken: cancellationToken);
+        Debug.Assert(doc.RootElement.ValueKind == JsonValueKind.Object);
+        return doc.RootElement.GetProperty("hits"u8).EnumerateArrayThenSelectToArray(static x => Parse(x));
     }
 
     public async Task<IEnumerable<ModrinthResourceFile>> GetModFilesByProjectIdAsync(string projectId, CancellationToken cancellationToken = default) {
@@ -63,13 +64,11 @@ public sealed class ModrinthProvider {
 
         var request = HttpUtil.Request(ModrinthApi, "project", projectId, "version");
 
-        var json = await request.GetStringAsync(cancellationToken: cancellationToken);
-        var jsonArray = json.AsNode().AsArray();
-
-        if (jsonArray is null)
-            return null;
-
-        return jsonArray.Select(ParseFile);
+        await using var json = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var jsonArray = await JsonDocument.ParseAsync(json, cancellationToken: cancellationToken);
+        Debug.Assert(jsonArray.RootElement.ValueKind == JsonValueKind.Array);
+        
+        return jsonArray.RootElement.EnumerateArrayThenSelectToArray(ParseFile);
     }
 
     public async Task<ModrinthResource> SearchByProjectIdAsync(string projectId, CancellationToken cancellationToken = default) {
@@ -77,8 +76,9 @@ public sealed class ModrinthProvider {
             .AppendPathSegments("project", projectId);
 
         var request = HttpUtil.Request(url);
-        var responseMessage = await request.GetStringAsync(cancellationToken: cancellationToken);
-        return Parse(responseMessage.AsNode());
+        await using var responseMessage = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var doc =  await JsonDocument.ParseAsync(responseMessage, cancellationToken: cancellationToken);
+        return Parse(doc.RootElement);
     }
 
     public async Task<IEnumerable<ModrinthResource>> SearchByProjectIdsAsync(IEnumerable<string> projectIds, CancellationToken cancellationToken = default) {
@@ -88,22 +88,19 @@ public sealed class ModrinthProvider {
             .AppendQueryParam("ids", idsJson, true);
 
         var request = HttpUtil.Request(url);
-        var responseMessage = await request.GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = responseMessage.AsNode();
-
-        return jsonNode.GetEnumerable().Select(x => Parse(x, true));
+        await using var responseMessage = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(responseMessage, cancellationToken: cancellationToken);
+        return doc.RootElement.EnumerateArrayThenSelectToArray(static x => Parse(x, true));
     }
 
     public async Task<IEnumerable<ModrinthResource>> SearchByUserAsync(string user, CancellationToken cancellationToken = default) {
         var request = HttpUtil.Request(ModrinthApi, "user", user, "projects");
 
-        var json = await request.GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = json.AsNode();
+        await using var json = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(json, cancellationToken: cancellationToken);
+        
 
-        if (jsonNode is null)
-            return [];
-
-        return jsonNode.GetEnumerable().Select(x => {
+        return doc.RootElement.EnumerateArrayThenSelectToArray(x => {
             var resource = Parse(x, true);
             resource.Author = user;
             return resource;
@@ -163,76 +160,99 @@ public sealed class ModrinthProvider {
 
         var request = HttpUtil.Request(url);
 
-        var json = await request.GetStringAsync(cancellationToken: cancellationToken);
-        var jsonNode = json.AsNode();
-
-        return jsonNode.GetEnumerable("hits").Select(x => Parse(x));
+        await using var json = await request.GetStreamAsync(cancellationToken: cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(json, cancellationToken: cancellationToken);
+        return doc.RootElement.GetProperty("hits"u8).EnumerateArrayThenSelectToArray(static x=>Parse(x));
     }
 
     #region Private
 
-    private static ModrinthResource Parse(JsonNode jsonNode, bool isDetail = false) {
+    private static ModrinthResource Parse(JsonElement jsonNode, bool isDetail = false) {
+        Debug.Assert(jsonNode.ValueKind == JsonValueKind.Object);
         return new ModrinthResource {
-            Slug = jsonNode.GetString("slug"),
-            Name = jsonNode.GetString("title"),
-            ProjectId = jsonNode.GetString("project_id"),
-            Author = jsonNode.GetString("author"),
-            IconUrl = jsonNode.GetString("icon_url"),
-            Summary = jsonNode.GetString("description"),
-            ProjectType = jsonNode.GetString("project_type"),
-            DownloadCount = jsonNode.GetInt32("downloads"),
-            Categories = jsonNode.GetEnumerable<string>("categories"),
+            Slug = jsonNode.GetProperty("slug"u8).GetString(),
+            Name = jsonNode.GetProperty("title"u8).GetString(),
+            ProjectId = jsonNode.GetProperty("project_id"u8).GetString(),
+            Author = jsonNode.TryGetProperty("author"u8, out var authorElement) ? authorElement.GetString() : null,
+            IconUrl = jsonNode.GetProperty("icon_url"u8).GetString(),
+            Summary = jsonNode.GetProperty("description"u8).GetString(),
+            ProjectType = jsonNode.GetProperty("project_type"u8).GetString(),
+            DownloadCount = jsonNode.GetProperty("downloads"u8).GetInt32(),
+            Categories = jsonNode.GetProperty("categories"u8)
+                .EnumerateArrayThenSelectToArray(x => x.GetString()),
             Screenshots = isDetail
-                ? jsonNode?.GetEnumerable<string>("gallery", "url")
-                : jsonNode?.GetEnumerable<string>("gallery"),
+                ? jsonNode.TryGetProperty("gallery"u8, out var galleryDetail)
+                    ? galleryDetail.EnumerateArrayThenSelectToArray(static x => x.GetProperty("url"u8).GetString())
+                    : null
+                : jsonNode.TryGetProperty("gallery"u8, out var gallery)
+                    ? gallery.EnumerateArrayThenSelectToArray(static x => x.GetString())
+                    : null,
             MinecraftVersions = isDetail
-                ? jsonNode?.GetEnumerable<string>("game_versions")
-                : jsonNode?.GetEnumerable<string>("versions"),
-            Updated = jsonNode.TryGetValue<DateTime>("date_modified", out var updated)
+                ? jsonNode.TryGetProperty("game_versions"u8, out var gameVersions)
+                    ? gameVersions.EnumerateArrayThenSelectToArray(static x => x.GetString())
+                    : null
+                : jsonNode.TryGetProperty("versions"u8, out var versions)
+                    ? versions.EnumerateArrayThenSelectToArray(static x => x.GetString())
+                    : null,
+            Updated = jsonNode.TryGetProperty("date_modified"u8, out var updatedEl) && updatedEl.TryGetDateTime(out var
+                updated)
                 ? updated
-                : jsonNode.GetDateTime("updated"),
-            DateModified = jsonNode.TryGetValue<DateTime>("date_created", out var published)
+                : jsonNode.GetProperty("updated"u8).GetDateTime(),
+            DateModified = jsonNode.TryGetProperty("date_created"u8, out var publishedEl) &&
+                           publishedEl.TryGetDateTime(out var published)
                 ? published
-                : jsonNode.GetDateTime("published")
+                : jsonNode.GetProperty("published"u8).GetDateTime()
         };
     }
+    [return: NotNull]
+    private static ModrinthResourceFile ParseFile(JsonElement node)
+    {
+        Debug.Assert(node.ValueKind == JsonValueKind.Object);
+        var filesElement = node.GetProperty("files"u8);
+        Debug.Assert(filesElement.ValueKind == JsonValueKind.Array);
+        JsonElement primaryFileNode = filesElement[0];
+        foreach (var item in filesElement.EnumerateArray())
+        {
+            if (!item.TryGetProperty("primary"u8, out var isPrimaryElement) || !isPrimaryElement.GetBoolean()) continue;
+            primaryFileNode = item;
+            break;
+        }
+        return new ModrinthResourceFile
+        {
+            VersionId = node.GetProperty("id"u8).GetString(),
+            AuthorId = node.GetProperty("author_id"u8).GetString(),
+            ProjectId = node.GetProperty("project_id"u8).GetString(),
+            Published = node.GetProperty("date_published"u8).GetDateTime(),
+            DownloadCount = node.GetProperty("downloads"u8).GetInt64(),
 
-    private static ModrinthResourceFile ParseFile(JsonNode node) {
-        var files = node.GetEnumerable("files");
-        var primaryFileNode = files
-            .FirstOrDefault(x => x.GetBool("primary")) ?? files.FirstOrDefault();
-        
-        return new() {
-            VersionId = node.GetString("id"),
-            AuthorId = node.GetString("author_id"),
-            ProjectId = node.GetString("project_id"),
-            Published = node.GetDateTime("date_published"),
-            DownloadCount = node.GetInt64("downloads").Value,
+            DisplayName = node.GetProperty("name"u8).GetString(),
+            ChangeLog = node.GetProperty("changelog"u8).GetString(),
+            VersionNumber = node.GetProperty("version_number"u8).GetString(),
+            MinecraftVersions = node.GetProperty("game_versions"u8)
+                .EnumerateArrayThenSelectToArray(x => x.GetString()),
 
-            DisplayName = node.GetString("name"),
-            ChangeLog = node.GetString("changelog"),
-            VersionNumber = node.GetString("version_number"),
-            MinecraftVersions = node.GetEnumerable<string>("game_versions"),
+            DownloadUrl = primaryFileNode.GetProperty("url"u8).GetString(),
+            IsPrimary = primaryFileNode.GetProperty("primary"u8).GetBoolean(),
+            FileName = primaryFileNode.GetProperty("filename"u8).GetString(),
+            FileSize = primaryFileNode.GetProperty("size"u8).GetInt64(),
+            Sha1 = primaryFileNode.GetProperty("hashes"u8).GetProperty("sha1"u8).GetString(),
+            Sha512 = primaryFileNode.GetProperty("hashes"u8).GetProperty("sha512"u8).GetString(),
 
-            DownloadUrl = primaryFileNode.GetString("url"),
-            IsPrimary = primaryFileNode.GetBool("primary"),
-            FileName = primaryFileNode.GetString("filename"),
-            FileSize = primaryFileNode.GetInt64("size").Value,
-            Sha1 = primaryFileNode.Select("hashes").GetString("sha1"),
-            Sha512 = primaryFileNode.Select("hashes").GetString("sha512"),
-
-            ReleaseType = node.GetString("version_type") switch {
+            ReleaseType = node.GetProperty("version_type"u8).GetString() switch
+            {
                 "release" => FileReleaseType.Release,
                 "beta" => FileReleaseType.Beta,
                 "alpha" => FileReleaseType.Alpha,
                 _ => throw new NotImplementedException()
             },
 
-            Dependencies = node.GetEnumerable("dependencies").Select(x => new ModrinthFileDependency {
-                FileName = x.GetString("file_name"),
-                VersionId = x.GetString("version_id"),
-                ProjectId = x.GetString("project_id"),
-                Type = x.GetString("dependency_type") switch {
+            Dependencies = node.GetProperty("dependencies"u8).EnumerateArrayThenSelectToArray(x => new ModrinthFileDependency
+            {
+                FileName = x.GetProperty("file_name"u8).GetString(),
+                VersionId = x.GetProperty("version_id"u8).GetString(),
+                ProjectId = x.GetProperty("project_id"u8).GetString(),
+                Type = x.GetProperty("dependency_type"u8).GetString() switch
+                {
                     "required" => DependencyType.Required,
                     "optional" => DependencyType.Optional,
                     "incompatible" => DependencyType.Incompatible,
@@ -241,7 +261,8 @@ public sealed class ModrinthProvider {
                 }
             }),
 
-            ModLoaders = node.GetEnumerable<string>("loaders").Select(x => x switch {
+            ModLoaders = node.GetProperty("loaders"u8).EnumerateArrayThenSelectToArray(x => x.GetString() switch
+            {
                 "fabric" => ModLoaderType.Fabric,
                 "forge" => ModLoaderType.Forge,
                 "quilt" => ModLoaderType.Quilt,

--- a/MinecraftLaunch/Components/Provider/SkinProvider.cs
+++ b/MinecraftLaunch/Components/Provider/SkinProvider.cs
@@ -1,8 +1,9 @@
-﻿using Flurl.Http;
+﻿using System.Diagnostics;
+using Flurl.Http;
 using MinecraftLaunch.Base.Models.Authentication;
 using MinecraftLaunch.Extensions;
 using MinecraftLaunch.Utilities;
-using System.Text;
+using System.Text.Json;
 
 namespace MinecraftLaunch.Components.Provider;
 
@@ -23,19 +24,25 @@ public sealed class SkinProvider {
     }
 
     private static async Task<Stream> GetSkinDataAsync(string url, CancellationToken cancellationToken) {
-        var baseJson = await HttpUtil.Request(url).GetStringAsync(cancellationToken: cancellationToken);
-        var baseNode = baseJson?.AsNode();
+        await using var stream = await HttpUtil.Request(url).GetStreamAsync(cancellationToken: cancellationToken);
+        byte[] base64;
+        using (var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken))
+        {
+            var baseNode = doc.RootElement;
 
-        var base64 = baseNode?.GetEnumerable("properties")
-            ?.FirstOrDefault()
-            ?.GetString("value");
+            var nullableBase64Element = baseNode.GetPropertyNullable("properties"u8);
+            Debug.Assert(nullableBase64Element?.ValueKind is null or JsonValueKind.Array);
+            base64 = nullableBase64Element?[0].GetPropertyNullable("value"u8)?.GetBytesFromBase64() ?? throw new InvalidOperationException();
+        }
+        using var skinDoc = JsonDocument.Parse(base64);
+        
+        var skinNode = skinDoc.RootElement;
 
-        var skinJson = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
-        var skinNode = skinJson.AsNode();
-
-        var skinUrl = skinNode?.Select("textures")?
-            .Select("SKIN")?
-            .GetString("url");
+        var skinUrl = skinNode
+            .GetPropertyNullable("textures"u8)?
+            .GetPropertyNullable("SKIN"u8)?
+            .GetPropertyNullable("url"u8)?
+            .GetString();
 
         return await HttpUtil.Request(skinUrl).GetStreamAsync(cancellationToken: cancellationToken);
     }

--- a/MinecraftLaunch/Extensions/JsonNodeExtension.cs
+++ b/MinecraftLaunch/Extensions/JsonNodeExtension.cs
@@ -55,6 +55,22 @@ public static partial class JsonNodeExtension {
         return JsonNode.Parse(json);
     }
 
+    public static JsonElement? GetPropertyNullable(this JsonElement element, ReadOnlySpan<char> propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var value))
+        {
+            return value;
+        }
+        return null;
+    }
+    public static JsonElement? GetPropertyNullable(this JsonElement element, ReadOnlySpan<byte> propertyNameUtf8)
+    {
+        if (element.TryGetProperty(propertyNameUtf8, out var value))
+        {
+            return value;
+        }
+        return null;
+    }
     public static JsonArray AsArray(this IEnumerable<JsonNode> jsonNodes) {
         return [.. jsonNodes];
     }

--- a/MinecraftLaunch/Extensions/JsonNodeExtension.cs
+++ b/MinecraftLaunch/Extensions/JsonNodeExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Buffers;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
@@ -165,6 +166,31 @@ public static partial class JsonNodeExtension {
             }).Where(v => v is not null)!;
     }
 
+    internal static TResult[] EnumerateArrayThenSelectToArray<TResult>(in this JsonElement arrayElement,
+        Func<JsonElement, TResult> selector)
+    {
+        var offset = 0;
+        var buffer = new TResult[arrayElement.GetArrayLength()];
+        foreach (var item in arrayElement.EnumerateArray())
+        {
+            buffer[offset++] = selector(item);
+        }
+        return buffer;
+    }
+    internal static string[] EnumerateArrayThenSelectNotNullStringPropertyWithNotNullAndNotEmptyValueThenToArray(this JsonElement arrayElement, ReadOnlySpan<byte> elementName)
+    {
+        var offset = 0;
+        var buffer = ArrayPool<string>.Shared.Rent(arrayElement.GetArrayLength());
+        foreach (var item in arrayElement.EnumerateArray())
+        {
+            if(!item.TryGetProperty(elementName, out var innerProperty))continue;
+            buffer[offset++] = innerProperty.GetString();
+        }
+        // 这可能会多次拷贝开销
+        var result = buffer[..offset];
+        ArrayPool<string>.Shared.Return(buffer);
+        return result;
+    }
     [GeneratedRegex(@"^""[^""]*""\s*:")]
     private static partial Regex JsonFieldRegex();
 

--- a/MinecraftLaunch/Extensions/MinecraftEntryExtension.cs
+++ b/MinecraftLaunch/Extensions/MinecraftEntryExtension.cs
@@ -2,9 +2,7 @@
 using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Utilities;
 using System.IO.Compression;
-using System.Security.Cryptography;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace MinecraftLaunch.Extensions;
 
@@ -12,25 +10,16 @@ public static class MinecraftEntryExtension {
     public static JavaEntry GetAppropriateJava(this MinecraftEntry minecraft, IEnumerable<JavaEntry> javas) {
         var targetJavaVersion = minecraft.GetAppropriateJavaVersion();
 
-        bool isForgeOrNeoForge = false;
-        List<JavaEntry> possiblyAvailableJavas = [];
+        var isForgeOrNeoForge = false;
 
-        if (minecraft is ModifiedMinecraftEntry modifiedMinecraft) {
-            var loaders = modifiedMinecraft.ModLoaders.Select(x => x.Type);
-            isForgeOrNeoForge = loaders.Contains(ModLoaderType.Forge) || loaders.Contains(ModLoaderType.NeoForge);
+        if (minecraft is ModifiedMinecraftEntry modifiedMinecraft)
+        {
+            isForgeOrNeoForge = modifiedMinecraft.ModLoaders.Any(static x => x.Type is ModLoaderType.Forge or ModLoaderType.NeoForge);
         }
 
-        possiblyAvailableJavas = targetJavaVersion is 0 or -1
-            ? [.. javas]
-            : isForgeOrNeoForge
-                ? [.. javas.Where(x => x.MajorVersion.Equals(targetJavaVersion))]
-                : [.. javas.Where(x => x.MajorVersion >= targetJavaVersion)];
-
-        if (possiblyAvailableJavas.Count == 0)
-            throw new FileNotFoundException($"No suitable version of Java found to start this game, version {targetJavaVersion} is required");
-
-        possiblyAvailableJavas.Reverse();
-        return possiblyAvailableJavas.First();
+        if (targetJavaVersion is 0 or -1) return javas.Last();
+        if (isForgeOrNeoForge) return javas.Last(x => x.MajorVersion == targetJavaVersion);
+        else return javas.Last(x => x.MajorVersion >= targetJavaVersion);
     }
 
     public static int GetAppropriateJavaVersion(this MinecraftEntry minecraft) {

--- a/MinecraftLaunch/Extensions/MinecraftEntryExtension.cs
+++ b/MinecraftLaunch/Extensions/MinecraftEntryExtension.cs
@@ -2,6 +2,8 @@
 using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Utilities;
 using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace MinecraftLaunch.Extensions;
@@ -35,24 +37,26 @@ public static class MinecraftEntryExtension {
         if (minecraft is ModifiedMinecraftEntry { HasInheritance: true } mc)
             return mc.InheritedMinecraft.GetAppropriateJavaVersion();
 
-        var majorJavaVersionNode = File.ReadAllText(minecraft.ClientJsonPath).AsNode()
-            .Select("javaVersion")?
-            .Select("majorVersion");
-
-        return majorJavaVersionNode is null
-            ? 8
-            : majorJavaVersionNode.GetInt32();
+        using var stream = File.OpenRead(minecraft.ClientJsonPath);
+        using var doc =  JsonDocument.Parse(stream);
+        if (doc.RootElement.TryGetProperty("javaVersion"u8, out var javaVersionElement) &&
+            javaVersionElement.TryGetProperty("majorVersion"u8, out var majorVersionElement))
+        {
+            return majorVersionElement.GetInt32();
+        }
+        return 8;
+        
     }
 
     public static MinecraftClient GetJarElement(this MinecraftEntry entry) {
         string clientJsonPath = entry.ClientJsonPath;
         if (entry is ModifiedMinecraftEntry { HasInheritance: true } inst)
             clientJsonPath = inst.InheritedMinecraft.ClientJsonPath;
-
-        JsonNode clientArtifactNode = File.ReadAllText(clientJsonPath).AsNode().Select("downloads")?.Select("client");
-
-        if (clientArtifactNode is null)
-            return null;
+        using var stream = File.OpenRead(clientJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+        if (!doc.RootElement.TryGetProperty("downloads"u8, out var downloadsElement) ||
+            !downloadsElement.TryGetProperty("client", out var clientArtifactNode)) return null;
+        
 
         string clientJarPath = entry.ClientJarPath;
         if (entry is ModifiedMinecraftEntry { HasInheritance: true } inst_)
@@ -61,11 +65,11 @@ public static class MinecraftEntryExtension {
         if (clientJarPath is null)
             return null;
 
-        long? size = clientArtifactNode.GetInt64("size");
-        string url = clientArtifactNode.GetString("url");
-        string sha1 = clientArtifactNode.GetString("sha1");
+        long size = clientArtifactNode.GetProperty("size"u8).GetInt64();
+        string url = clientArtifactNode.GetProperty("url"u8).GetString();
+        string sha1 = clientArtifactNode.GetProperty("sha1"u8).GetString();
 
-        if (sha1 is null || url is null || size is null)
+        if (sha1 is null || url is null)
             throw new InvalidDataException("Invalid client info");
 
         return new MinecraftClient {
@@ -73,7 +77,7 @@ public static class MinecraftEntryExtension {
             ClientId = Path.GetFileNameWithoutExtension(clientJarPath),
             Url = url,
             Sha1 = sha1,
-            Size = size.Value
+            Size = size
         };
     }
 
@@ -82,16 +86,18 @@ public static class MinecraftEntryExtension {
         string clientJsonPath = minecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } entry
             ? entry.InheritedMinecraft.ClientJsonPath
             : minecraftEntry.ClientJsonPath;
-
+        
         // Parse client.json
-        JsonNode jsonNode = JsonNode.Parse(File.ReadAllText(clientJsonPath));
-        var assetIndex = jsonNode.Select("assetIndex")
-            ?? throw new InvalidDataException("Error in parsing version.json");
+        using var stream = File.OpenRead(clientJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+        var root = doc.RootElement;
+        if(!root.TryGetProperty("assetIndex"u8, out var assetIndex))throw new InvalidDataException("Error in parsing version.json");
+        
 
-        long size = assetIndex.GetInt64("size").Value;
-        string id = assetIndex.GetString("id") ?? throw new InvalidDataException();
-        string url = assetIndex.GetString("url") ?? throw new InvalidDataException();
-        string sha1 = assetIndex.GetString("sha1") ?? throw new InvalidDataException();
+        long size = assetIndex.GetProperty("size"u8).GetInt64();
+        string id = assetIndex.GetProperty("id"u8).GetString() ?? throw new InvalidDataException();
+        string url = assetIndex.GetProperty("url"u8).GetString() ?? throw new InvalidDataException();
+        string sha1 = assetIndex.GetProperty("sha1"u8).GetString() ?? throw new InvalidDataException();
 
         return new AssstIndex {
             Id = id,


### PR DESCRIPTION
此PR在**尽量不改变逻辑**的情况下对许多地方进行了替换,但是由于API差异以及测试难度导致我无法进行较为完整的测试以验证行为是否`完全`符合预期
## 内容
+ File.ReadAllText等string相关API被部分替换为Stream为主的流式API
+ JsonNode.Parse被部分替换为JsonDocument.Parse(或Async)并确保释放
+ File.WriteAllText等被替换为Stream等API减少字符串拷贝/反序列化/序列化开销
+ 合并一些LINQ的逻辑以及手写部分LINQ(保证可读性) 以期减少SOH GC
## 行为变更
+ 对于原先使用`LINQ`进行**惰性求值**的场景被替换为**立刻终结迭代器**,这使得部分**函数执行时间延长**
   但是对于UI场景,这种修改通常会获得更好的性能
+ ML虽主要以接口遍历集合,但是具体类型还是比较重要的,这影响着LINQ性能
   + 在修改之前
        - 多数类型为接口的属性以`LINQ`中的`Select`返回
        - 多数函数以`LINQ`返回
   + 在修改之后
        - T[]
        - T[]或者List[]
   + 修改原因
        - 在此之前,LINQ闭包保存着`JsonNode`,这显著增加了JsonNode这一分散的结构长时间占据内存
          此修改可以归类为优化的一部分
        - 更主要的原因,JsonDocument生命期较短,释放后不可使用
          这与`惰性求值`冲突,为确保逻辑正确性,采取立即终结的方式

## 合并前的需要
### 测试本PR相关API是否正常
#### 原因: 我没有现成的,较为完整的启动器/Benchmark/UnitTest供测试,尽管我已在控制台程序中进行了小规模测试,但是会影响API使用的极端情况在小规模测试中难以体现
#### 主要需要关注的部分
+ 相关函数是否空安全
   + JsonNode的空检查比JsonElement松得多
   + 虽然大部分API都使用Try相关函数来避免原API行为以外的异常,但是可能存在疏忽
+ 资源泄露(已检查)

## other
是否存在develop分支?或者我可以开放此fork的权限