### PR TITLE
ModPack提取Overrides文件加速

### DIFF
--- a/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/CurseforgeModpackInstaller.cs
@@ -193,36 +193,25 @@ public sealed class CurseforgeModpackInstaller : InstallerBase {
     }
 
     private async Task ExtractModpackAsync(CancellationToken cancellationToken) {
-        var zipArchive = ZipFile.OpenRead(ModpackPath);
-        var entries = zipArchive?.Entries;
-        ReportProgress(InstallStep.ExtractModpack, 0.85d, TaskStatus.Running, entries.Count, 0);
+      
+        ReportProgress(InstallStep.ExtractModpack, 0.85d, TaskStatus.Running, 0, 0); // 此处未开始解析,返回0
 
-        int count = 0;
-        var tasks = entries.Select(x => Task.Run(() => {
-            lock (zipArchive) {
-                ReportProgress(InstallStep.ExtractModpack,
-                    ((double)Interlocked.Increment(ref count) / (double)entries.Count).ToPercentage(0.85d, 1.0d),
-                    TaskStatus.Running, entries.Count, count);
-
-                if (!Entry.IsOverride ||
-                    !x.FullName.StartsWith(Entry.Overrides, StringComparison.OrdinalIgnoreCase)) return;
-
-                var subPath = x.FullName[(Entry.Overrides.Length + 1)..];
-                if (string.IsNullOrEmpty(subPath))
-                    return;
-
-                var filePath = new FileInfo(Path.Combine(Path.GetFullPath(Minecraft.ToWorkingPath(true)), subPath));
-                if (x.FullName.EndsWith('/')) {
-                    Directory.CreateDirectory(filePath.FullName);
-                    return;
-                }
-
-                x.ExtractTo(filePath.FullName);
-            }
-        }, cancellationToken));
-
-        await Task.WhenAll(tasks);
-        zipArchive.Dispose();
+        var count = 0; 
+        await ModPackUtils.ExtractSingleThreadAsync(
+            srcZipPath: ModpackPath,
+            overridesPrefix: Entry.Overrides,
+            independentAndFullWorkingPath: Minecraft.ToWorkingPath(true),
+            whenEachEntryCompleted: ReportEntryExtractingProgress,
+            cancellationToken: cancellationToken);
+        return;
+        
+        void ReportEntryExtractingProgress(ZipArchive zipArchive) =>
+            ReportProgress(
+                step: InstallStep.ExtractModpack, 
+                progress: (Interlocked.Increment(ref count) / (double)zipArchive.Entries.Count).ToPercentage(0.85d, 1.0d),
+                status:  TaskStatus.Running,
+                totalCount: zipArchive.Entries.Count,
+                finshedCount: count);
     }
 
     #endregion

--- a/MinecraftLaunch/Components/Installer/Modpack/McbbsModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/McbbsModpackInstaller.cs
@@ -75,39 +75,28 @@ public sealed class McbbsModpackInstaller : InstallerBase {
     #region Privates
 
     private async Task ExtractModpackAsync(CancellationToken cancellationToken) {
-        var zipArchive = ZipFile.OpenRead(ModpackPath);
-        var entries = zipArchive?.Entries;
-        ReportProgress(InstallStep.ExtractModpack, 0.10d, TaskStatus.Running, entries.Count, 0);
+      
+        ReportProgress(InstallStep.ExtractModpack, 0.85d, TaskStatus.Running, 0, 0); // 此处未开始解析,返回0
 
         const string decompressPrefix = "overrides";
-        string woringPath = Minecraft.ToWorkingPath(true);
 
-        int count = 0;
-        var tasks = entries.Select(x => Task.Run(() => {
-            lock (zipArchive) {
-                ReportProgress(InstallStep.ExtractModpack,
-                    ((double)Interlocked.Increment(ref count) / (double)entries.Count).ToPercentage(0.1d, 1.0d),
-                    TaskStatus.Running, entries.Count, count);
+        var count = 0; 
+        await ModPackUtils.ExtractSingleThreadAsync(
+            srcZipPath: ModpackPath,
+            overridesPrefix: decompressPrefix,
+            independentAndFullWorkingPath: Minecraft.ToWorkingPath(true),
+            whenEachEntryCompleted: ReportEntryExtractingProgress,
+            cancellationToken: cancellationToken);
+        return;
+        
 
-                if (!x.FullName.StartsWith(decompressPrefix))
-                    return;
-
-                var subPath = x.FullName[(decompressPrefix.Length + 1)..];
-                if (string.IsNullOrEmpty(subPath))
-                    return;
-
-                var filePath = new FileInfo(Path.Combine(woringPath, subPath));
-                if (x.FullName.EndsWith('/')) {
-                    filePath.Directory.Create();
-                    return;
-                }
-
-                x.ExtractTo(filePath.FullName);
-            }
-        }, cancellationToken));
-
-        await Task.WhenAll(tasks);
-        zipArchive.Dispose();
+        void ReportEntryExtractingProgress(ZipArchive zipArchive) =>
+            ReportProgress(
+                step: InstallStep.ExtractModpack, 
+                progress: (Interlocked.Increment(ref count) / (double)zipArchive.Entries.Count).ToPercentage(0.85d, 1.0d),
+                status:  TaskStatus.Running,
+                totalCount: zipArchive.Entries.Count,
+                finshedCount: count);
     }
 
     #endregion

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -1,0 +1,129 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using MinecraftLaunch.Extensions;
+
+namespace MinecraftLaunch.Components.Installer.Modpack;
+
+internal static class ModPackUtils
+{
+    public const char ZipPathSeparator = '/';
+    public static Task ExtractModpackAsync(
+        [NotNull] string srcZipPath,
+        [NotNull] string overridesPrefix,
+        [NotNull] string independentAndFullWorkingPath,
+        bool enableParallelAcceleration,
+        CancellationToken cancelToken = default)
+    {
+        
+
+        cancelToken.ThrowIfCancellationRequested();
+        if (enableParallelAcceleration)
+            return ParallelAccelerationAsync(srcZipPath, overridesPrefix, independentAndFullWorkingPath, cancelToken);
+        return SingleThreadAsync(srcZipPath, overridesPrefix, independentAndFullWorkingPath, cancelToken);
+
+        // 修正路径
+        static string RemoveOverridesPrefix(
+            string source,
+            string overridesPrefix)
+        {
+            if (overridesPrefix.EndsWith('/'))
+            {
+                return source[overridesPrefix.Length..];
+            }
+
+            // 补充/
+            return source[(overridesPrefix.Length + 1)..];
+        }
+
+        // 判断是否需要排除
+        static bool IsShouldExtract(
+            ZipArchiveEntry entry,
+            string overridesPrefix)
+        {
+            // 排除目录
+            if (entry.FullName.EndsWith(ZipPathSeparator)) return false;
+            // 排除非 <overrides>/文件
+            if (!entry.FullName.StartsWith(overridesPrefix, StringComparison.OrdinalIgnoreCase)) return false;
+            return true;
+        }
+
+        // 多线程
+        static async Task ParallelAccelerationAsync(
+            string srcZipPath,
+            string overridesPrefix,
+            string independentAndFullWorkingPath,
+            CancellationToken cancelToken)
+        {
+            // 从-1开始即第一次递增后为0
+            const int startOffset = -1;
+            //Init
+            var parallelCount = Environment.ProcessorCount * 2;
+            var taskThreads = new Task[parallelCount];
+            var zips = new ZipArchive[parallelCount];
+            var targetOffset = startOffset;
+            var concurrentOffset = startOffset;
+            for (var i = 0; i < parallelCount; i++)
+            {
+                zips[i] = ZipFile.OpenRead(srcZipPath);
+                // 首次循环读取长度
+                if (i is 0) targetOffset = zips[0].Entries.Count;
+                // 拷贝tid用于不同实例闭包
+                var taskThreadId = i;
+                taskThreads[i] = Task.Run(ExtractManyJob, cancelToken);
+                continue;
+
+                // main job
+                async Task ExtractManyJob()
+                {
+                    while (true)
+                    {
+                        cancelToken.ThrowIfCancellationRequested();
+                        var entryIndex = Interlocked.Increment(ref concurrentOffset);
+                        // entries已全部复制
+                        // targetOffset不会被修改
+                        // ReSharper disable once AccessToModifiedClosure
+                        if (entryIndex >= targetOffset) return;
+                        var entry = zips[taskThreadId].Entries[entryIndex];
+                        if (!IsShouldExtract(entry, overridesPrefix)) continue;
+                        // 获取路径
+                        var dstPath = Path.Combine(independentAndFullWorkingPath,
+                            RemoveOverridesPrefix(entry.FullName, overridesPrefix));
+                        // 复制
+                        await entry.ExtractToFileAsync(dstPath);
+                    }
+                }
+            }
+
+            // 确保资源释放,Task只会在await时重新抛出
+            try
+            {
+                await Task.WhenAll(taskThreads);
+            }
+            finally
+            {
+                foreach (var zip in zips) zip.Dispose();
+            }
+        }
+
+        // 单线程
+        static async Task SingleThreadAsync(
+            string srcZipPath,
+            string overridesPrefix,
+            string independentAndFullWorkingPath,
+            CancellationToken cancelToken)
+        {
+            using var zip = ZipFile.OpenRead(srcZipPath);
+            foreach (var item in zip.Entries)
+            {
+                cancelToken.ThrowIfCancellationRequested();
+                if (!IsShouldExtract(item, overridesPrefix)) continue;
+                await item.ExtractToFileAsync(
+                    Path.Combine(
+                        independentAndFullWorkingPath,
+                        RemoveOverridesPrefix(item.FullName, overridesPrefix))
+                );
+            }
+        }
+    }
+    
+}

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -14,8 +14,8 @@ internal static class ModPackUtils
         string srcZipPath,
         string overridesPrefix,
         string independentAndFullWorkingPath,
-        Action<ZipArchive> whenEachEntryCompleted = null,
-        CancellationToken cancelToken = default)
+        /*执行线程不保证*/Action<ZipArchive> whenEachEntryCompleted = null,
+        CancellationToken cancellationToken = default)
     {
         // 从-1开始即第一次递增后为0
         const int startOffset = -1;
@@ -32,7 +32,7 @@ internal static class ModPackUtils
             if (i is 0) targetOffset = zips[0].Entries.Count;
             // 拷贝tid用于不同实例闭包
             var taskThreadId = i;
-            taskThreads[i] = Task.Run(ExtractManyJob, cancelToken);
+            taskThreads[i] = Task.Run(ExtractManyJob, cancellationToken);
             continue;
 
             // main job
@@ -40,7 +40,7 @@ internal static class ModPackUtils
             {
                 while (true)
                 {
-                    cancelToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     var entryIndex = Interlocked.Increment(ref concurrentOffset);
                     // entries已全部复制
                     // targetOffset不会被修改
@@ -52,7 +52,7 @@ internal static class ModPackUtils
                     var dstPath = Path.Combine(independentAndFullWorkingPath,
                         RemoveOverridesPrefix(entry.FullName, overridesPrefix));
                     // 复制
-                    await entry.ExtractToFileAsync(dstPath);
+                    await entry.ExtractToFileAsync(dstPath,true,cancellationToken).ConfigureAwait(false);
                     whenEachEntryCompleted?.Invoke(zips[taskThreadId]);
                 }
             }
@@ -73,19 +73,20 @@ internal static class ModPackUtils
         string srcZipPath,
         string overridesPrefix,
         string independentAndFullWorkingPath,
-        Action<ZipArchive> whenEachEntryCompleted = null,
-        CancellationToken cancelToken = default)
+        /*执行线程不保证*/Action<ZipArchive> whenEachEntryCompleted = null,
+        CancellationToken cancellationToken = default)
     {
         using var zip = ZipFile.OpenRead(srcZipPath);
         foreach (var item in zip.Entries)
         {
-            cancelToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             if (!IsShouldExtract(item, overridesPrefix)) continue;
             await item.ExtractToFileAsync(
                 Path.Combine(
                     independentAndFullWorkingPath,
-                    RemoveOverridesPrefix(item.FullName, overridesPrefix))
-            );
+                    RemoveOverridesPrefix(item.FullName, overridesPrefix)),
+                overwrite:true,cancellationToken
+            ).ConfigureAwait(false);
             whenEachEntryCompleted?.Invoke(zip);
         }
     }

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Net.Sockets;
 using MinecraftLaunch.Extensions;
@@ -17,6 +18,8 @@ internal static class ModPackUtils
         /*执行线程不保证*/Action<ZipArchive> whenEachEntryCompleted = null,
         CancellationToken cancellationToken = default)
     {
+        Debug.Assert(srcZipPath is not null || overridesPrefix is not null || independentAndFullWorkingPath is not null);
+        cancellationToken.ThrowIfCancellationRequested(); 
         using var zip = ZipFile.OpenRead(srcZipPath);
         foreach (var item in zip.Entries)
         {

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -21,11 +21,19 @@ internal static class ModPackUtils
         foreach (var item in zip.Entries)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            // 排除非 <overrides>/文件
+            if (!item.FullName.StartsWith(overridesPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+            var targetPath = Path.Combine(
+                independentAndFullWorkingPath,
+                RemoveOverridesPrefix(item.FullName, overridesPrefix));
+            if (item.FullName.EndsWith(ZipPathSeparator))
+            {
+                Directory.CreateDirectory(targetPath);
+                continue;
+            }
             if (!IsShouldExtract(item, overridesPrefix)) continue;
             await item.ExtractToFileAsync(
-                Path.Combine(
-                    independentAndFullWorkingPath,
-                    RemoveOverridesPrefix(item.FullName, overridesPrefix)),
+                targetPath,
                 overwrite:true,cancellationToken
             ).ConfigureAwait(false);
             whenEachEntryCompleted?.Invoke(zip);

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -14,6 +14,7 @@ internal static class ModPackUtils
         string srcZipPath,
         string overridesPrefix,
         string independentAndFullWorkingPath,
+        Action<ZipArchive> whenEachEntryCompleted = null,
         CancellationToken cancelToken = default)
     {
         // 从-1开始即第一次递增后为0
@@ -52,6 +53,7 @@ internal static class ModPackUtils
                         RemoveOverridesPrefix(entry.FullName, overridesPrefix));
                     // 复制
                     await entry.ExtractToFileAsync(dstPath);
+                    whenEachEntryCompleted?.Invoke(zips[taskThreadId]);
                 }
             }
         }
@@ -71,6 +73,7 @@ internal static class ModPackUtils
         string srcZipPath,
         string overridesPrefix,
         string independentAndFullWorkingPath,
+        Action<ZipArchive> whenEachEntryCompleted = null,
         CancellationToken cancelToken = default)
     {
         using var zip = ZipFile.OpenRead(srcZipPath);
@@ -83,6 +86,7 @@ internal static class ModPackUtils
                     independentAndFullWorkingPath,
                     RemoveOverridesPrefix(item.FullName, overridesPrefix))
             );
+            whenEachEntryCompleted?.Invoke(zip);
         }
     }
 

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -10,65 +10,6 @@ internal static class ModPackUtils
     public const char ZipPathSeparator = '/';
     
 
-    public static async Task ExtractParallelAccelerationAsync(
-        string srcZipPath,
-        string overridesPrefix,
-        string independentAndFullWorkingPath,
-        /*执行线程不保证*/Action<ZipArchive> whenEachEntryCompleted = null,
-        CancellationToken cancellationToken = default)
-    {
-        // 从-1开始即第一次递增后为0
-        const int startOffset = -1;
-        //Init
-        var parallelCount = Environment.ProcessorCount * 2;
-        var taskThreads = new Task[parallelCount];
-        var zips = new ZipArchive[parallelCount];
-        var targetOffset = startOffset;
-        var concurrentOffset = startOffset;
-        for (var i = 0; i < parallelCount; i++)
-        {
-            zips[i] = ZipFile.OpenRead(srcZipPath);
-            // 首次循环读取长度
-            if (i is 0) targetOffset = zips[0].Entries.Count;
-            // 拷贝tid用于不同实例闭包
-            var taskThreadId = i;
-            taskThreads[i] = Task.Run(ExtractManyJob, cancellationToken);
-            continue;
-
-            // main job
-            async Task ExtractManyJob()
-            {
-                while (true)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var entryIndex = Interlocked.Increment(ref concurrentOffset);
-                    // entries已全部复制
-                    // targetOffset不会被修改
-                    // ReSharper disable once AccessToModifiedClosure
-                    if (entryIndex >= targetOffset) return;
-                    var entry = zips[taskThreadId].Entries[entryIndex];
-                    if (!IsShouldExtract(entry, overridesPrefix)) continue;
-                    // 获取路径
-                    var dstPath = Path.Combine(independentAndFullWorkingPath,
-                        RemoveOverridesPrefix(entry.FullName, overridesPrefix));
-                    // 复制
-                    await entry.ExtractToFileAsync(dstPath,true,cancellationToken).ConfigureAwait(false);
-                    whenEachEntryCompleted?.Invoke(zips[taskThreadId]);
-                }
-            }
-        }
-
-        // 确保资源释放,Task只会在await时重新抛出
-        try
-        {
-            await Task.WhenAll(taskThreads);
-        }
-        finally
-        {
-            foreach (var zip in zips) zip.Dispose();
-        }
-    }
-
     public static async Task ExtractSingleThreadAsync(
         string srcZipPath,
         string overridesPrefix,

--- a/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModPackUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
+using System.Net.Sockets;
 using MinecraftLaunch.Extensions;
 
 namespace MinecraftLaunch.Components.Installer.Modpack;
@@ -7,123 +8,110 @@ namespace MinecraftLaunch.Components.Installer.Modpack;
 internal static class ModPackUtils
 {
     public const char ZipPathSeparator = '/';
-    public static Task ExtractModpackAsync(
-        [NotNull] string srcZipPath,
-        [NotNull] string overridesPrefix,
-        [NotNull] string independentAndFullWorkingPath,
-        bool enableParallelAcceleration,
+    
+
+    public static async Task ExtractParallelAccelerationAsync(
+        string srcZipPath,
+        string overridesPrefix,
+        string independentAndFullWorkingPath,
         CancellationToken cancelToken = default)
     {
-        
-
-        cancelToken.ThrowIfCancellationRequested();
-        if (enableParallelAcceleration)
-            return ParallelAccelerationAsync(srcZipPath, overridesPrefix, independentAndFullWorkingPath, cancelToken);
-        return SingleThreadAsync(srcZipPath, overridesPrefix, independentAndFullWorkingPath, cancelToken);
-
-        // 修正路径
-        static string RemoveOverridesPrefix(
-            string source,
-            string overridesPrefix)
+        // 从-1开始即第一次递增后为0
+        const int startOffset = -1;
+        //Init
+        var parallelCount = Environment.ProcessorCount * 2;
+        var taskThreads = new Task[parallelCount];
+        var zips = new ZipArchive[parallelCount];
+        var targetOffset = startOffset;
+        var concurrentOffset = startOffset;
+        for (var i = 0; i < parallelCount; i++)
         {
-            if (overridesPrefix.EndsWith('/'))
+            zips[i] = ZipFile.OpenRead(srcZipPath);
+            // 首次循环读取长度
+            if (i is 0) targetOffset = zips[0].Entries.Count;
+            // 拷贝tid用于不同实例闭包
+            var taskThreadId = i;
+            taskThreads[i] = Task.Run(ExtractManyJob, cancelToken);
+            continue;
+
+            // main job
+            async Task ExtractManyJob()
             {
-                return source[overridesPrefix.Length..];
-            }
-
-            // 补充/
-            return source[(overridesPrefix.Length + 1)..];
-        }
-
-        // 判断是否需要排除
-        static bool IsShouldExtract(
-            ZipArchiveEntry entry,
-            string overridesPrefix)
-        {
-            // 排除目录
-            if (entry.FullName.EndsWith(ZipPathSeparator)) return false;
-            // 排除非 <overrides>/文件
-            if (!entry.FullName.StartsWith(overridesPrefix, StringComparison.OrdinalIgnoreCase)) return false;
-            return true;
-        }
-
-        // 多线程
-        static async Task ParallelAccelerationAsync(
-            string srcZipPath,
-            string overridesPrefix,
-            string independentAndFullWorkingPath,
-            CancellationToken cancelToken)
-        {
-            // 从-1开始即第一次递增后为0
-            const int startOffset = -1;
-            //Init
-            var parallelCount = Environment.ProcessorCount * 2;
-            var taskThreads = new Task[parallelCount];
-            var zips = new ZipArchive[parallelCount];
-            var targetOffset = startOffset;
-            var concurrentOffset = startOffset;
-            for (var i = 0; i < parallelCount; i++)
-            {
-                zips[i] = ZipFile.OpenRead(srcZipPath);
-                // 首次循环读取长度
-                if (i is 0) targetOffset = zips[0].Entries.Count;
-                // 拷贝tid用于不同实例闭包
-                var taskThreadId = i;
-                taskThreads[i] = Task.Run(ExtractManyJob, cancelToken);
-                continue;
-
-                // main job
-                async Task ExtractManyJob()
+                while (true)
                 {
-                    while (true)
-                    {
-                        cancelToken.ThrowIfCancellationRequested();
-                        var entryIndex = Interlocked.Increment(ref concurrentOffset);
-                        // entries已全部复制
-                        // targetOffset不会被修改
-                        // ReSharper disable once AccessToModifiedClosure
-                        if (entryIndex >= targetOffset) return;
-                        var entry = zips[taskThreadId].Entries[entryIndex];
-                        if (!IsShouldExtract(entry, overridesPrefix)) continue;
-                        // 获取路径
-                        var dstPath = Path.Combine(independentAndFullWorkingPath,
-                            RemoveOverridesPrefix(entry.FullName, overridesPrefix));
-                        // 复制
-                        await entry.ExtractToFileAsync(dstPath);
-                    }
+                    cancelToken.ThrowIfCancellationRequested();
+                    var entryIndex = Interlocked.Increment(ref concurrentOffset);
+                    // entries已全部复制
+                    // targetOffset不会被修改
+                    // ReSharper disable once AccessToModifiedClosure
+                    if (entryIndex >= targetOffset) return;
+                    var entry = zips[taskThreadId].Entries[entryIndex];
+                    if (!IsShouldExtract(entry, overridesPrefix)) continue;
+                    // 获取路径
+                    var dstPath = Path.Combine(independentAndFullWorkingPath,
+                        RemoveOverridesPrefix(entry.FullName, overridesPrefix));
+                    // 复制
+                    await entry.ExtractToFileAsync(dstPath);
                 }
             }
-
-            // 确保资源释放,Task只会在await时重新抛出
-            try
-            {
-                await Task.WhenAll(taskThreads);
-            }
-            finally
-            {
-                foreach (var zip in zips) zip.Dispose();
-            }
         }
 
-        // 单线程
-        static async Task SingleThreadAsync(
-            string srcZipPath,
-            string overridesPrefix,
-            string independentAndFullWorkingPath,
-            CancellationToken cancelToken)
+        // 确保资源释放,Task只会在await时重新抛出
+        try
         {
-            using var zip = ZipFile.OpenRead(srcZipPath);
-            foreach (var item in zip.Entries)
-            {
-                cancelToken.ThrowIfCancellationRequested();
-                if (!IsShouldExtract(item, overridesPrefix)) continue;
-                await item.ExtractToFileAsync(
-                    Path.Combine(
-                        independentAndFullWorkingPath,
-                        RemoveOverridesPrefix(item.FullName, overridesPrefix))
-                );
-            }
+            await Task.WhenAll(taskThreads);
+        }
+        finally
+        {
+            foreach (var zip in zips) zip.Dispose();
         }
     }
-    
+
+    public static async Task ExtractSingleThreadAsync(
+        string srcZipPath,
+        string overridesPrefix,
+        string independentAndFullWorkingPath,
+        CancellationToken cancelToken = default)
+    {
+        using var zip = ZipFile.OpenRead(srcZipPath);
+        foreach (var item in zip.Entries)
+        {
+            cancelToken.ThrowIfCancellationRequested();
+            if (!IsShouldExtract(item, overridesPrefix)) continue;
+            await item.ExtractToFileAsync(
+                Path.Combine(
+                    independentAndFullWorkingPath,
+                    RemoveOverridesPrefix(item.FullName, overridesPrefix))
+            );
+        }
+    }
+
+    #region Util
+
+    private static bool IsShouldExtract(
+        ZipArchiveEntry entry,
+        string overridesPrefix)
+    {
+        // 排除目录
+        if (entry.FullName.EndsWith(ZipPathSeparator)) return false;
+        // 排除非 <overrides>/文件
+        if (!entry.FullName.StartsWith(overridesPrefix, StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    // 修正路径
+    private static string RemoveOverridesPrefix(
+        string source,
+        string overridesPrefix)
+    {
+        if (overridesPrefix.EndsWith('/'))
+        {
+            return source[overridesPrefix.Length..];
+        }
+
+        // 补充/
+        return source[(overridesPrefix.Length + 1)..];
+    }
+
+    #endregion
 }

--- a/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
@@ -111,39 +111,28 @@ public sealed class ModrinthModpackInstaller : InstallerBase {
     }
 
     private async Task ExtractModpackAsync(CancellationToken cancellationToken) {
-        var zipArchive = ZipFile.OpenRead(ModpackPath);
-        var entries = zipArchive?.Entries;
-        ReportProgress(InstallStep.ExtractModpack, 0.85d, TaskStatus.Running, entries.Count, 0);
+      
+        ReportProgress(InstallStep.ExtractModpack, 0.85d, TaskStatus.Running, 0, 0); // 此处未开始解析,返回0
 
         const string decompressPrefix = "overrides";
-        string woringPath = Minecraft.ToWorkingPath(true);
 
-        int count = 0;
-        var tasks = entries.Select(x => Task.Run(() => {
-            lock (zipArchive) {
-                ReportProgress(InstallStep.ExtractModpack,
-                    ((double)Interlocked.Increment(ref count) / (double)entries.Count).ToPercentage(0.85d, 1.0d),
-                    TaskStatus.Running, entries.Count, count);
+        var count = 0; 
+        await ModPackUtils.ExtractSingleThreadAsync(
+            srcZipPath: ModpackPath,
+            overridesPrefix: decompressPrefix,
+            independentAndFullWorkingPath: Minecraft.ToWorkingPath(true),
+            whenEachEntryCompleted: ReportEntryExtractingProgress,
+            cancellationToken: cancellationToken);
+       return;
+        
 
-                if (!x.FullName.StartsWith(decompressPrefix)) 
-                    return;
-
-                var subPath = x.FullName[(decompressPrefix.Length + 1)..];
-                if (string.IsNullOrEmpty(subPath))
-                    return;
-
-                var filePath = new FileInfo(Path.Combine(woringPath, subPath));
-                if (x.FullName.EndsWith('/')) {
-                    filePath.Directory.Create();
-                    return;
-                }
-
-                x.ExtractTo(filePath.FullName);
-            }
-        }, cancellationToken));
-
-        await Task.WhenAll(tasks);
-        zipArchive.Dispose();
+        void ReportEntryExtractingProgress(ZipArchive zipArchive) =>
+            ReportProgress(
+                step: InstallStep.ExtractModpack, 
+                progress: (Interlocked.Increment(ref count) / (double)zipArchive.Entries.Count).ToPercentage(0.85d, 1.0d),
+                status:  TaskStatus.Running,
+                totalCount: zipArchive.Entries.Count,
+                finshedCount: count);
     }
 
     #endregion

--- a/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
@@ -70,30 +70,37 @@ public sealed class ModrinthModpackInstaller : InstallerBase {
 
     #region Privates
 
-    private IEnumerable<DownloadRequest> ParseModFiles(CancellationToken cancellationToken) {
-        int totalCount = Entry.Files.Count();
-        ReportProgress(InstallStep.ParseDownloadUrls, 0.1d, TaskStatus.Running, totalCount, 0);
-
-        int count = 0;
-        string versionPath = Minecraft.ToWorkingPath(true);
-        foreach (var file in Entry.Files.AsParallel()) {
+    private IEnumerable<DownloadRequest> ParseModFiles(CancellationToken cancellationToken)
+    {
+        const double minProgress = 0.1d;
+        const double maxProgress = 0.45d;
+        var fileArray = Entry.Files.ToArray();
+        var constTotalCount = fileArray.Length;
+        ReportProgress(
+            step: InstallStep.ParseDownloadUrls,
+            progress: 0.1d,
+            status: TaskStatus.Running,
+            totalCount: constTotalCount, 
+            finshedCount: 0);
+        double count = 0;
+        var versionPath = Minecraft.ToWorkingPath(true);
+        //不对Parallel进行Foreach,直接不Parallel
+        return fileArray.Select(fileItem =>
+        {
             cancellationToken.ThrowIfCancellationRequested();
-
-            lock (Entry) {
-                double progress = (double)Interlocked.Increment(ref count) / (double)totalCount;
-                ReportProgress(InstallStep.ParseDownloadUrls, progress.ToPercentage(0.1d, 0.45d),
-                    TaskStatus.Running, totalCount, count);
-            }
-
-            if (!file.Downloads.Any())
-                continue;
-
-            if (string.IsNullOrEmpty(file.Path))
-                continue;
-
-            var filePath = Path.Combine(versionPath, file.Path);
-            yield return new DownloadRequest(file.Downloads.First(), filePath);
-        }
+            // 非多线程且同个闭包可见性好,无需原子操作
+            ReportProgress(
+                step: InstallStep.ParseDownloadUrls,
+                // ReSharper disable once AccessToModifiedClosure
+                progress: (++count / constTotalCount).ToPercentage(minProgress, maxProgress),
+                status: TaskStatus.Running,
+                totalCount: constTotalCount,
+                finshedCount: 0);
+            if (!fileItem.Downloads.Any()) return null;
+            if (string.IsNullOrEmpty(fileItem.Path)) return null;
+            var filePath = Path.Combine(versionPath, fileItem.Path);
+            return new DownloadRequest(fileItem.Downloads.First(), filePath);
+        }).Where(static x => x is not null);
     }
 
     private Task<GroupDownloadResult> DownloadModsAsync(IEnumerable<DownloadRequest> downloadRequests, CancellationToken cancellationToken) {

--- a/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
+++ b/MinecraftLaunch/Components/Installer/Modpack/ModrinthModpackInstaller.cs
@@ -25,18 +25,18 @@ public sealed class ModrinthModpackInstaller : InstallerBase {
     }
 
     public static async Task<IInstallEntry> ParseModLoaderEntryAsync(ModrinthModpackInstallEntry modpack, CancellationToken cancellationToken = default) {
-        if (modpack.Dependencies.ContainsKey("fabric-loader"))
+        if (modpack.Dependencies.TryGetValue("fabric-loader", out var modpackDependency1))
             return (await FabricInstaller.EnumerableFabricAsync(modpack.McVersion, cancellationToken: cancellationToken))
-                .First(x => x.BuildVersion.Equals(modpack.Dependencies["fabric-loader"]));
-        else if (modpack.Dependencies.ContainsKey("quilt-loader"))
+                .First(x => x.BuildVersion.Equals(modpackDependency1));
+        else if (modpack.Dependencies.TryGetValue("quilt-loader", out var dependency1))
             return (await QuiltInstaller.EnumerableQuiltAsync(modpack.McVersion, cancellationToken))
-                .First(x => x.BuildVersion.Equals(modpack.Dependencies["quilt-loader"]));
-        else if (modpack.Dependencies.ContainsKey("forge"))
+                .First(x => x.BuildVersion.Equals(dependency1));
+        else if (modpack.Dependencies.TryGetValue("forge", out var modpackDependency))
             return (await ForgeInstaller.EnumerableForgeAsync(modpack.McVersion, false, cancellationToken))
-                .First(x => x.ForgeVersion.Equals(modpack.Dependencies["forge"]));
-        else if (modpack.Dependencies.ContainsKey("neoforge"))
+                .First(x => x.ForgeVersion.Equals(modpackDependency));
+        else if (modpack.Dependencies.TryGetValue("neoforge", out var dependency))
             return (await ForgeInstaller.EnumerableForgeAsync(modpack.McVersion, true, cancellationToken))
-                .First(x => x.ForgeVersion.Equals(modpack.Dependencies["neoforge"]));
+                .First(x => x.ForgeVersion.Equals(dependency));
         else
             throw new NotSupportedException();
     }

--- a/MinecraftLaunch/Extensions/ZipArchiveExtension.cs
+++ b/MinecraftLaunch/Extensions/ZipArchiveExtension.cs
@@ -19,4 +19,11 @@ public static class ZipArchiveExtension {
 
         zipArchiveEntry.ExtractToFile(destinationFile, true);
     }
+
+    public static async Task ExtractToFileAsync(this ZipArchiveEntry zipArchiveEntry, string destinationFile)
+    {
+        await using var dst = File.OpenWrite(destinationFile);
+        await using var src = zipArchiveEntry.Open();
+        await src.CopyToAsync(dst);
+    }
 }

--- a/MinecraftLaunch/Extensions/ZipArchiveExtension.cs
+++ b/MinecraftLaunch/Extensions/ZipArchiveExtension.cs
@@ -20,10 +20,47 @@ public static class ZipArchiveExtension {
         zipArchiveEntry.ExtractToFile(destinationFile, true);
     }
 
-    public static async Task ExtractToFileAsync(this ZipArchiveEntry zipArchiveEntry, string destinationFile)
+    // Licensed to the .NET Foundation under one or more agreements.
+    // The .NET Foundation licenses this file to you under the MIT license.
+    // -> The .NET Foundation licenses this function to us under the MIT license.
+    // 使用了.net标准库代码
+    private static void ExtractToFileInitialize(ZipArchiveEntry source, string destinationFileName, bool overwrite, out FileStreamOptions fileStreamOptions)
     {
-        await using var dst = File.OpenWrite(destinationFile);
-        await using var src = zipArchiveEntry.Open();
-        await src.CopyToAsync(dst);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(destinationFileName);
+
+        fileStreamOptions = new()
+        {
+            Access = FileAccess.Write,
+            Mode = overwrite ? FileMode.Create : FileMode.CreateNew,
+            Share = FileShare.None,
+            BufferSize = 16384
+        };
+
+        const UnixFileMode OwnershipPermissions =
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+        // Restore Unix permissions.
+        // For security, limit to ownership permissions, and respect umask (through UnixCreateMode).
+        // We don't apply UnixFileMode.None because .zip files created on Windows and .zip files created
+        // with previous versions of .NET don't include permissions.
+        UnixFileMode mode = (UnixFileMode)(source.ExternalAttributes >> 16) & OwnershipPermissions;
+        if (mode != UnixFileMode.None && !OperatingSystem.IsWindows())
+        {
+            fileStreamOptions.UnixCreateMode = mode;
+        }
+    }
+    // Licensed to the .NET Foundation under one or more agreements.
+    // The .NET Foundation licenses this file to you under the MIT license.
+    internal static async Task ExtractToFileAsync(this ZipArchiveEntry zipArchiveEntry, string destinationFile,bool overwrite,CancellationToken cts)
+    {
+        cts.ThrowIfCancellationRequested();
+        ExtractToFileInitialize(zipArchiveEntry, destinationFile, overwrite, out var fileStreamOptions);
+        await using var dst = new FileStream(destinationFile, fileStreamOptions);
+        await using var src = zipArchiveEntry.Open(); // OpenAsync真搬不了吧(),等xilu速速换NET10单目标即可
+        await src.CopyToAsync(dst, cts).ConfigureAwait(false);
+        File.SetLastWriteTime(destinationFile,DateTime.Now);
     }
 }


### PR DESCRIPTION
1 在` MinecraftLaunch.Extensions.ZipArchiveExtension` 中移植了.NET10内置的`ExtractToFileAsync`以提升响应性
2 基于 `1.`实现了整合包提取,删去了原先的锁以减少锁开销
3 减少了部分无必要的原子操作(无必要的: 可视且无竞态的)