### PR TITLE
feat(launcher): 添加对 Minecraft 版本参数规则解析和 PCL 兼容性支持

### DIFF
--- a/src/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
+++ b/src/MinecraftLaunch.Base/Models/Game/MinecraftEntry.cs
@@ -460,7 +460,7 @@ public abstract partial class MinecraftLibrary : MinecraftDependency {
                 MinecraftFolderPath = minecraftFolderPath,
                 IsNativeLibrary = false,
                 Size = libNode.Size,
-                Sha1 = libNode.Sha1!.Value
+                Sha1 = libNode.Sha1
             };
         }
 

--- a/src/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
+++ b/src/MinecraftLaunch.Base/Models/Game/MinecraftJsonEntry.cs
@@ -25,6 +25,7 @@ public record MinecraftJsonEntry {
     /// <summary> ValueType is Array </summary>
     [JsonPropertyName("libraries")] public JsonElement Libraries { get; set; }
     [JsonPropertyName("inheritsFrom")] public string InheritsFrom { get; set; }
+    [JsonPropertyName("jar")] public string Jar { get; set; }
     [JsonPropertyName("javaVersion")] public JsonElement JavaVersion { get; set; }
     [JsonPropertyName("releaseTime")] public DateTime ReleaseTime { get; set; }
     [JsonPropertyName("assetIndex")] public AssstIndexJsonEntry AssetIndex { get; set; }

--- a/src/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
+++ b/src/MinecraftLaunch/Components/Parser/ArgumentsParser.cs
@@ -4,7 +4,9 @@ using MinecraftLaunch.Base.Models.Game;
 using MinecraftLaunch.Base.Utilities;
 using MinecraftLaunch.Extensions;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace MinecraftLaunch.Components.Parser;
 
@@ -63,7 +65,7 @@ public sealed class ArgumentsParser
                 }
                 else if (lib.Name == containedLib.Name
                          && lib.Classifier == containedLib.Classifier
-                         && lib.Domain == lib.Domain)
+                          && lib.Domain == containedLib.Domain)
                 {
                     sameNameLib = containedLib;
                     break;
@@ -171,7 +173,9 @@ public sealed class ArgumentsParser
             { "${launcher_version}", "4" },
             { "${classpath_separator}", Path.PathSeparator.ToString() },
             { "${library_directory}", MinecraftEntry.ToLibrariesPath().ToPath() },
+            { "${libraries_directory}", MinecraftEntry.ToLibrariesPath().ToPath() },
             { "${classpath}", classPath.ToPath() },
+            { "${primary_jar}", MinecraftEntry.ClientJarPath.ToPath() },
             {
                 "${version_name}", MinecraftEntry is ModifiedMinecraftEntry { HasInheritance: true } instance
                     ? instance.InheritedMinecraft.Id.ToPath()
@@ -206,8 +210,11 @@ public sealed class ArgumentsParser
         {
             { "${auth_player_name}", LaunchConfig.Account.Name },
             { "${auth_access_token}", LaunchConfig.Account.AccessToken },
+            { "${access_token}", LaunchConfig.Account.AccessToken },
             { "${auth_session}", LaunchConfig.Account.AccessToken },
             { "${auth_uuid}", LaunchConfig.Account.Uuid.ToString("N") },
+            { "${clientid}", string.Empty },
+            { "${auth_xuid}", string.Empty },
             { "${user_type}", LaunchConfig.Account.Type.Equals(AccountType.Microsoft) ? "MSA" : "Mojang" },
             { "${user_properties}", "{}" },
             { "${version_name}", MinecraftEntry.Id.ToPath() },
@@ -281,9 +288,8 @@ internal sealed class GameArgumentParser
             yield break;
         
 
-        var game = gameElement.EnumerateArray()
-            .Where(x => x.ValueKind is JsonValueKind.String)
-            .Select(x => x.GetString().ToPath())
+        var game = VersionArgumentRuleParser.Parse(gameElement)
+            .Select(x => x.ToPath())
             .GroupArguments();
 
         foreach (var item in game)
@@ -307,17 +313,14 @@ internal sealed class JvmArgumentParser
             yield break;
         }
         var jvm = new List<string>();
-        foreach (var arg in jvmElement.EnumerateArray())
+        foreach (var argValue in VersionArgumentRuleParser.Parse(jvmElement))
         {
-            if (arg.ValueKind is JsonValueKind.String)
-            {
-                var argValue = arg.GetString()!.Trim();
+            var value = argValue.Trim();
 
-                if (argValue.Contains(' '))
-                    jvm.AddRange(argValue.Split(' '));
-                else
-                    jvm.Add(argValue);
-            }
+            if (value.Contains(' '))
+                jvm.AddRange(value.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+            else
+                jvm.Add(value);
         }
 
         foreach (var arg in jvm.GroupArguments())
@@ -352,5 +355,91 @@ internal sealed class JvmArgumentParser
 
         if (EnvironmentUtil.Arch == "32")
             yield return "-Xss1M";
+    }
+}
+
+internal static class VersionArgumentRuleParser
+{
+    public static IEnumerable<string> Parse(JsonElement arguments)
+    {
+        foreach (var argument in arguments.EnumerateArray())
+        {
+            if (argument.ValueKind == JsonValueKind.String)
+            {
+                yield return argument.GetString()!;
+                continue;
+            }
+
+            if (argument.ValueKind != JsonValueKind.Object
+                || !argument.TryGetProperty("value"u8, out var value)
+                || argument.TryGetProperty("rules"u8, out var rules) && !AreRulesAllowed(rules))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+                yield return value.GetString()!;
+            else if (value.ValueKind == JsonValueKind.Array)
+                foreach (var item in value.EnumerateArray())
+                    if (item.ValueKind == JsonValueKind.String)
+                        yield return item.GetString()!;
+        }
+    }
+
+    private static bool AreRulesAllowed(JsonElement rules)
+    {
+        bool allowed = false;
+        foreach (var rule in rules.EnumerateArray())
+        {
+            if (!RuleMatches(rule))
+                continue;
+
+            allowed = rule.TryGetProperty("action"u8, out var action)
+                      && action.ValueEquals("allow"u8);
+        }
+
+        return allowed;
+    }
+
+    private static bool RuleMatches(JsonElement rule)
+    {
+        // Feature flags require launcher state (demo user, quick play, custom resolution).
+        // These arguments are added separately by ArgumentsParser, so do not enable them blindly.
+        if (rule.TryGetProperty("features"u8, out _))
+            return false;
+
+        if (!rule.TryGetProperty("os"u8, out var os))
+            return true;
+
+        if (os.TryGetProperty("name"u8, out var name)
+            && !string.Equals(name.GetString(), EnvironmentUtil.GetPlatformName(), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (os.TryGetProperty("arch"u8, out var arch))
+        {
+            string currentArch = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X86 => "x86",
+                Architecture.X64 => "x86_64",
+                Architecture.Arm => "arm",
+                Architecture.Arm64 => "arm64",
+                _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
+            };
+            if (!string.Equals(arch.GetString(), currentArch, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        if (os.TryGetProperty("version"u8, out var version))
+        {
+            try
+            {
+                if (!Regex.IsMatch(Environment.OSVersion.VersionString, version.GetString()!))
+                    return false;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/MinecraftLaunch/Components/Parser/MinecraftParser.cs
+++ b/src/MinecraftLaunch/Components/Parser/MinecraftParser.cs
@@ -52,6 +52,10 @@ public sealed class MinecraftParser {
 
         foreach (DirectoryInfo dir in versionsDirectory.EnumerateDirectories())
         {
+            // PCL uses this marker while an instance is still being installed.
+            if (File.Exists(Path.Combine(dir.FullName, ".pclignore")))
+                continue;
+
             var entry = Parse(dir, list, out bool inheritedInstanceAlreadyFound);
             int index = list.FindIndex(i => i.Id == entry.Id);
             if (index != -1)
@@ -78,10 +82,12 @@ public sealed class MinecraftParser {
         if (!clientDir.Exists)
             throw new DirectoryNotFoundException($"{clientDir.FullName} not found");
 
-        // Find client.json
-        var clientJsonFile = clientDir
-            .GetFiles($"{clientDir.Name}.json")
-            .FirstOrDefault()
+        if (File.Exists(Path.Combine(clientDir.FullName, ".pclignore")))
+            throw new InvalidOperationException($"Minecraft instance {clientDir.Name} is still being installed by PCL");
+
+        // PCL accepts a valid version JSON even when it does not match the folder name.
+        var clientJsonFile = clientDir.GetFiles($"{clientDir.Name}.json").FirstOrDefault()
+            ?? FindFallbackClientJson(clientDir)
             ?? throw new FileNotFoundException($"client.json not found in {clientDir.FullName}");
         string clientJsonPath = clientJsonFile.FullName;
 
@@ -104,6 +110,25 @@ public sealed class MinecraftParser {
         return IsVanilla(clientJsonObject)
             ? ParseVanilla(partialData, clientJsonObject, doc.RootElement)
             : ParseModified(partialData, clientJsonObject, doc.RootElement, parsedInstances, out foundInheritedInstanceInParsed);
+    }
+
+    private static FileInfo FindFallbackClientJson(DirectoryInfo clientDir) {
+        foreach (var file in clientDir.EnumerateFiles("*.json")) {
+            try {
+                using var stream = file.OpenRead();
+                using var document = JsonDocument.Parse(stream);
+                var root = document.RootElement;
+                if (root.ValueKind == JsonValueKind.Object
+                    && root.TryGetProperty("id"u8, out _)
+                    && (root.TryGetProperty("mainClass"u8, out _)
+                        || root.TryGetProperty("patches"u8, out _)))
+                    return file;
+            } catch (JsonException) {
+                // Other JSON files in a version directory are not necessarily version metadata.
+            }
+        }
+
+        return null;
     }
 
     private static bool IsVanilla(MinecraftJsonEntry clientJsonObject) {
@@ -146,13 +171,23 @@ public sealed class MinecraftParser {
     {
         Debug.Assert(clientJsonNode.ValueKind == JsonValueKind.Object);
         var versionId = gameJsonEntry.Id;
-        if (clientJsonNode.TryGetProperty("patches"u8, out var hmclPatchesNode))
+        if (clientJsonNode.TryGetProperty("clientVersion"u8, out var pclClientVersionNode)
+            && pclClientVersionNode.ValueKind == JsonValueKind.String)
         {
-            if(hmclPatchesNode.GetArrayLength() < 0)throw new FormatException("Failed to parse version id");
-            versionId = hmclPatchesNode[0].GetProperty("version"u8).GetString();
-        }
-        else if (clientJsonNode.TryGetProperty("clientVersion"u8, out var pclClientVersionNode)) 
             versionId = pclClientVersionNode.GetString();
+        }
+        else if (clientJsonNode.TryGetProperty("patches"u8, out var hmclPatchesNode)
+                 && hmclPatchesNode.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var patch in hmclPatchesNode.EnumerateArray()) {
+                if (patch.TryGetProperty("id"u8, out var idNode)
+                    && idNode.ValueEquals("game"u8)
+                    && patch.TryGetProperty("version"u8, out var versionNode)) {
+                    versionId = versionNode.GetString();
+                    break;
+                }
+            }
+        }
 
         return versionId ?? throw new FormatException("Failed to parse version id");
     }
@@ -212,9 +247,11 @@ public sealed class MinecraftParser {
                 : Path.Combine(partialData.MinecraftFolderPath, "assets", "indexes", $"{minecraftJsonEntry.AssetIndex.Id}.json");
 
         // Check if client.jar exists
-        string clientJarPath = hasInheritance
-            ? inheritedEntry.ClientJarPath
-            : partialData.ClientJsonPath[..^"json".Length] + "jar";
+        string clientJarPath = !string.IsNullOrWhiteSpace(minecraftJsonEntry.Jar)
+            ? Path.Combine(partialData.MinecraftFolderPath, "versions", minecraftJsonEntry.Jar, $"{minecraftJsonEntry.Jar}.jar")
+            : hasInheritance
+                ? inheritedEntry.ClientJarPath
+                : partialData.ClientJsonPath[..^"json".Length] + "jar";
 
         // Parse version
         MinecraftVersion? version;

--- a/src/MinecraftLaunch/Launch/MinecraftRunner.cs
+++ b/src/MinecraftLaunch/Launch/MinecraftRunner.cs
@@ -16,17 +16,12 @@ public sealed class MinecraftRunner {
     }
 
     public MinecraftProcess Run(string id) {
-        MinecraftEntry minecraft = default;
-        IEnumerable<string> arguments = [];
-        
-        try {
-            minecraft = _minecraftParser.GetMinecraft(id);
-            ArgumentsParser parser = new(minecraft, LaunchConfig);
-            arguments = parser.Parse();
+        MinecraftEntry minecraft = _minecraftParser.GetMinecraft(id);
+        ArgumentsParser parser = new(minecraft, LaunchConfig);
+        IEnumerable<string> arguments = parser.Parse();
 
-            if (string.IsNullOrEmpty(LaunchConfig.NativesFolder))
-                minecraft.ExtractNatives(parser.GetNatives());
-        } catch (Exception) {}
+        if (string.IsNullOrEmpty(LaunchConfig.NativesFolder))
+            minecraft.ExtractNatives(parser.GetNatives());
 
         return new MinecraftProcess(LaunchConfig, minecraft, arguments);
     }
@@ -34,17 +29,12 @@ public sealed class MinecraftRunner {
     public MinecraftProcess Run(MinecraftEntry minecraft) => Run(minecraft.Id);
 
     public async Task<MinecraftProcess> RunAsync(string id, CancellationToken cancellationToken = default) {
-        MinecraftEntry minecraft = default;
-        IEnumerable<string> arguments = [];
+        MinecraftEntry minecraft = _minecraftParser.GetMinecraft(id);
+        ArgumentsParser parser = new(minecraft, LaunchConfig);
+        IEnumerable<string> arguments = parser.Parse();
 
-        try {
-            minecraft = _minecraftParser.GetMinecraft(id);
-            ArgumentsParser parser = new(minecraft, LaunchConfig);
-            arguments = parser.Parse();
-
-            if (string.IsNullOrEmpty(LaunchConfig.NativesFolder))
-                await minecraft.ExtractNativesAsync(parser.GetNatives(), cancellationToken);
-        } catch (Exception) {}
+        if (string.IsNullOrEmpty(LaunchConfig.NativesFolder))
+            await minecraft.ExtractNativesAsync(parser.GetNatives(), cancellationToken);
 
         return new MinecraftProcess(LaunchConfig, minecraft, arguments);
     }


### PR DESCRIPTION
- 实现了 VersionArgumentRuleParser 类来解析游戏和 JVM 参数规则
- 添加了对 PCL 安装标记文件 .pclignore 的检测和处理
- 支持从 JSON 文件中解析 jar 属性指定客户端 JAR 文件路径
- 添加了 ${libraries_directory} 和 ${primary_jar} 环境变量替换
- 增加了 ${access_token}, ${clientid}, ${auth_xuid} 认证相关变量
- 实现了回退机制查找匹配的客户端 JSON 配置文件
- 支持解析 HMCL 和 PCL 格式的版本标识符
- 优化了 MinecraftRunner 中的异常处理逻辑